### PR TITLE
Fix mounting folders

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -129,7 +129,7 @@ func NewTGFApplication(args []string) *TGFApplication {
 	swFlagON("docker-build", "Enable docker build instructions configured in the config files").BoolVar(&app.DockerBuild)
 	swFlagON("home", "Enable mapping of the home directory").BoolVar(&app.MountHomeDir)
 	swFlagON("temp", "Map the temp folder to a local folder").BoolVar(&app.MountTempDir)
-	app.Flag("mount-point", "Specify a mount point for the current folder").PlaceHolder("<folder>").StringVar(&app.MountPoint)
+	app.Flag("mount-point", "Specify a mount point for the current folder").PlaceHolder("<folder>").Default("CurrentSources").StringVar(&app.MountPoint)
 	app.Flag("prune", "Remove all previous versions of the targeted image").BoolVar(&app.PruneImages)
 	app.Flag("docker-arg", "Supply extra argument to Docker").PlaceHolder("<opt>").StringsVar(&app.DockerOptions)
 	app.Flag("with-current-user", "Runs the docker command with the current user, using the --user arg").Alias("cu").BoolVar(&app.WithCurrentUser)

--- a/docker.go
+++ b/docker.go
@@ -98,7 +98,7 @@ func (docker *dockerConfig) call() int {
 	if app.MountHomeDir {
 		currentUser := must(user.Current()).(*user.User)
 		home := filepath.ToSlash(currentUser.HomeDir)
-		mountingHome := filepath.Join("/home", filepath.Base(home))
+		mountingHome := fmt.Sprintf("/home/%s", filepath.Base(home))
 
 		dockerArgs = append(dockerArgs, []string{
 			"-v", fmt.Sprintf("%v:%v", convertDrive(home), mountingHome),


### PR DESCRIPTION
The mounting folder for current working folder and the home folder depended of the host context and could lead to error when mapping host folders into the container. We now ensure that the working folder is always mapped to the mount point specified by --mount-point (default to /CurrentSources) and the home folder is mounted directly into /home (the default home folder on Linux)