### PR TITLE
[DT-3355] tgf install script fails on Linux when not executed as root

### DIFF
--- a/get-latest-tgf.sh
+++ b/get-latest-tgf.sh
@@ -9,7 +9,7 @@ if [ ! -d "${TGF_PATH}" ]; then
 fi
 
 if [ ! -w "${TGF_PATH}" ]; then
-  if [ ${TGF_PATH} == "${DEFAULT_INSTALL_DIR}" ]; then
+  if [ "${TGF_PATH}" == "${DEFAULT_INSTALL_DIR}" ]; then
     # This is a system directory.  It's not a good idea to try to make it writeable.
     echo "System installation directory ${TGF_PATH} is not writeable."
     echo "Please set the TGF_PATH environment variable to install to an alternate, writeable directory."
@@ -17,7 +17,7 @@ if [ ! -w "${TGF_PATH}" ]; then
   fi
 
 
-  if ! chmod ugo+w ${TGF_PATH}; then
+  if ! chmod ugo+w "${TGF_PATH}"; then
     echo "Cannot make installation directory ${TGF_PATH} writeable."
     echo "Please set the TGF_PATH environment variable to install to an alternate, writeable directory."
     exit 1
@@ -66,7 +66,7 @@ get_latest_tgf_version
 echo '- tgf version (local) :' "${TGF_LOCAL_VERSION}"
 echo '- tgf version (latest):' "${TGF_LATEST_VERSION}"
 
-if [[ ${TGF_LOCAL_VERSION} == "${TGF_LATEST_VERSION}" ]]
+if [[ "${TGF_LOCAL_VERSION}" == "${TGF_LATEST_VERSION}" ]]
 then 
     echo 'Local version is up to date.'
 else

--- a/get-latest-tgf.sh
+++ b/get-latest-tgf.sh
@@ -1,20 +1,38 @@
 #!/usr/bin/env bash
 
-TGF=${TGF_PATH:=/usr/local/bin}/tgf
+DEFAULT_INSTALL_DIR=/usr/local/bin
+TGF=${TGF_PATH:=${DEFAULT_INSTALL_DIR}}/tgf
 
-if [ ! -d "$TGF_PATH" ]; then
-  echo "creating "$TGF_PATH" directory..."
-  mkdir -p $TGF_PATH
+if [ ! -d "${TGF_PATH}" ]; then
+  echo "creating ${TGF_PATH} directory..."
+  mkdir -p ${TGF_PATH}
+fi
+
+if [ ! -w "${TGF_PATH}" ]; then
+  if [ ${TGF_PATH} == "${DEFAULT_INSTALL_DIR}" ]; then
+    # This is a system directory.  It's not a good idea to try to make it writeable.
+    echo "System installation directory ${TGF_PATH} is not writeable."
+    echo "Please set the TGF_PATH environment variable to install to an alternate, writeable directory."
+    exit 1
+  fi
+
+
+  if ! chmod ugo+w ${TGF_PATH}; then
+    echo "Cannot make installation directory ${TGF_PATH} writeable."
+    echo "Please set the TGF_PATH environment variable to install to an alternate, writeable directory."
+    exit 1
+  fi
 fi
 
 get_local_tgf_version () {
-    [ -r $TGF ] && TGF_LOCAL_VERSION=$($TGF --current-version | awk -F\ '{print $2}' | cut -d'v' -f 2)
+    # The sed regex extracts for example 1.23.2 from "tgf v1.23.2", so as to be comparable to get_latest_tgf_version()
+    [ -r ${TGF} ] && TGF_LOCAL_VERSION=$(${TGF} --current-version | sed -E -e 's/^.* v(.*)/\1/')
 }
 
 get_latest_tgf_version () {
     TGF_LATEST_VERSION=$(curl --silent https://coveo-bootstrap-us-east-1.s3.amazonaws.com/tgf_version.txt)
     
-    if [ -z "$TGF_LATEST_VERSION" ]
+    if [ -z "${TGF_LATEST_VERSION}" ]
     then 
         echo "Could not obtain tgf latest version."
         exit 1
@@ -23,7 +41,7 @@ get_latest_tgf_version () {
 
 script_end () {
     echo 'Done.'
-    $TGF --current-version
+    ${TGF} --current-version
     exit 0
 }
 
@@ -31,11 +49,11 @@ install_latest_tgf () {
     if [[ $(uname -s) == Linux ]]
     then
         echo 'Installing latest tgf version for Linux in' $TGF_PATH '...'
-        curl -sL "https://github.com/coveooss/tgf/releases/download/v"$TGF_LATEST_VERSION"/tgf_"$TGF_LATEST_VERSION"_linux_64-bits.zip" | gzip -d > $TGF && chmod +x $TGF && script_end
+        curl -sL "https://github.com/coveooss/tgf/releases/download/v${TGF_LATEST_VERSION}/tgf_${TGF_LATEST_VERSION}_linux_64-bits.zip" | gzip -d > ${TGF} && chmod +x ${TGF} && script_end
     elif [[ $(uname -s) == Darwin ]]
     then
         echo 'Installing latest tgf for OSX in' $TGF_PATH '...'
-        curl -sL "https://github.com/coveooss/tgf/releases/download/v"$TGF_LATEST_VERSION"/tgf_"$TGF_LATEST_VERSION"_macOS_64-bits.zip" | bsdtar -xf- -C $TGF_PATH && chmod +x $TGF && script_end
+        curl -sL "https://github.com/coveooss/tgf/releases/download/v${TGF_LATEST_VERSION}/tgf_${TGF_LATEST_VERSION}_macOS_64-bits.zip" | bsdtar -xf- -C ${TGF_PATH} && chmod +x ${TGF} && script_end
     else 
         echo 'OS not supported.'
         exit 1
@@ -45,10 +63,10 @@ install_latest_tgf () {
 get_local_tgf_version
 get_latest_tgf_version
 
-echo '- tgf version (local):' $TGF_LOCAL_VERSION
-echo '- tgf version (latest):' $TGF_LATEST_VERSION
+echo '- tgf version (local) :' "${TGF_LOCAL_VERSION}"
+echo '- tgf version (latest):' "${TGF_LATEST_VERSION}"
 
-if [[ $TGF_LOCAL_VERSION == $TGF_LATEST_VERSION ]]
+if [[ ${TGF_LOCAL_VERSION} == "${TGF_LATEST_VERSION}" ]]
 then 
     echo 'Local version is up to date.'
 else


### PR DESCRIPTION
* If cannot write to /usr/local/bin, instruct user to use another dir with TGF_PATH.
  The script doesn't try to make it writeable because it's a system directory.
* If cannot write to TGF_PATH, try to make it writeable.  If that fails, instruct
  user to use another directory.
* Fix get_local_tgf_version() that was returning nothing even when tgf was installed
* Fix shell quoting to be more solid (from warnings issued by IntelliJ shell editor plugin)

Tested manually under various scenarios in a docker container running ubuntu.
