### PR TITLE
Allow TGF_ARGS env variable with -- in command

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -223,9 +223,16 @@ func formatDescription() string {
 
 // Parse overrides the base Parse method
 func (app *TGFApplication) Parse(args []string) (command string, err error) {
-	// Split up the managed parameters from the unmanaged ones
+	// Add args from the TGF_ARGS env variable
 	if extraArgs, ok := os.LookupEnv(envArgs); ok {
-		args = append(args, strings.Split(extraArgs, " ")...)
+		nonEmptyArgs := []string{}
+		for _, extraArg := range strings.Split(extraArgs, " ") {
+			extraArg = strings.TrimSpace(extraArg)
+			if extraArg != "" {
+				nonEmptyArgs = append(nonEmptyArgs, extraArg)
+			}
+		}
+		args = append(nonEmptyArgs, args...)
 	}
 	if command, err = app.Application.Parse(args); err != nil {
 		panic(errors.Managed(err.Error()))

--- a/cli_test.go
+++ b/cli_test.go
@@ -10,11 +10,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func NewTestApplication(args []string) *TGFApplication {
-	for _, env := range os.Environ() {
-		if strings.HasPrefix(env, "TGF_") {
-			name, _ := collections.Split2(env, "=")
-			_ = os.Setenv(name, "")
+func NewTestApplication(args []string, unsetTgfArgs bool) *TGFApplication {
+	if unsetTgfArgs {
+		for _, env := range os.Environ() {
+			if strings.HasPrefix(env, "TGF_") {
+				name, _ := collections.Split2(env, "=")
+				_ = os.Setenv(name, "")
+			}
 		}
 	}
 	return NewTGFApplication(args)
@@ -26,87 +28,130 @@ func TestNewApplicationWithOptionsAndAliases(t *testing.T) {
 	tests := []struct {
 		name          string
 		args          []string
+		tgfArgsEnv    string
 		wantOptions   map[string]interface{}
 		wantUnmanaged []string
 	}{
 		{
 			"Empty",
 			[]string{},
+			"",
 			map[string]interface{}{},
 			nil,
 		},
 		{
 			"Managed arg",
 			[]string{"--ri"},
+			"",
 			map[string]interface{}{"Refresh": true, "DockerInteractive": true},
 			nil,
 		},
 		{
 			"Managed and unmanaged arg",
 			[]string{"--li", "--stuff"},
+			"",
 			map[string]interface{}{"UseLocalImage": true, "DockerInteractive": true},
 			[]string{"--stuff"},
 		},
 		{
 			"Alias with an unmanaged arg",
 			[]string{"my_recursive_alias", "--stuff4"},
+			"",
 			map[string]interface{}{"Refresh": true, "UseLocalImage": true, "WithDockerMount": true},
 			[]string{"--stuff3", "--stuff4"},
 		},
 		{
 			"Alias with an argument",
 			[]string{"my_recursive_alias", "--no-interactive"},
+			"",
 			map[string]interface{}{"DockerInteractive": false},
 			[]string{"--stuff3"},
 		},
 		{
 			"Disable flag (shown as `no` in the help)",
 			[]string{"--no-aws"},
+			"",
 			map[string]interface{}{"UseAWS": false, "DockerInteractive": true},
 			nil,
 		},
 		{
 			"Disable short flag (shown as `no` in the help)",
 			[]string{"--na"},
+			"",
 			map[string]interface{}{"UseAWS": false, "DockerInteractive": true},
 			nil,
 		},
 		{
 			"--temp = --temp-location host",
 			[]string{"--temp"},
+			"",
 			map[string]interface{}{"TempDirMountLocation": mountLocHost},
 			nil,
 		},
 		{
 			"--no-temp = --temp-location none",
 			[]string{"--no-temp"},
+			"",
 			map[string]interface{}{"TempDirMountLocation": mountLocNone},
 			nil,
 		},
 		{
 			"--temp-location wins over --temp",
 			[]string{"--temp", "--temp-location", "none"},
+			"",
 			map[string]interface{}{"TempDirMountLocation": mountLocNone},
 			nil,
 		},
 		{
 			"--temp-location wins over --no-temp",
 			[]string{"--temp-location", "host", "--no-temp"},
+			"",
 			map[string]interface{}{"TempDirMountLocation": mountLocHost},
 			nil,
 		},
 		{
 			"--temp-location default",
 			[]string{},
+			"",
 			map[string]interface{}{"TempDirMountLocation": mountLocVolume},
 			nil,
+		},
+		{
+			"tgf argument after -- are not evaluated",
+			[]string{"--temp-location", "host", "--", "--no-aws"},
+			"",
+			map[string]interface{}{"TempDirMountLocation": mountLocHost, "UseAWS": true},
+			[]string{"--no-aws"},
+		},
+		{
+			"tgf argument after -- are not evaluated #2",
+			[]string{"--temp-location", "host", "--no-aws", "--", "--no-aws"},
+			"",
+			map[string]interface{}{"TempDirMountLocation": mountLocHost, "UseAWS": false},
+			[]string{"--no-aws"},
+		},
+		{
+			"tgf argument from env args",
+			[]string{"--temp-location", "host"},
+			"--no-aws",
+			map[string]interface{}{"TempDirMountLocation": mountLocHost, "UseAWS": false},
+			nil,
+		},
+		{
+			"tgf argument from env args (with -- in command)",
+			[]string{"--temp-location", "host", "--", "--no-aws"},
+			"--no-aws",
+			map[string]interface{}{"TempDirMountLocation": mountLocHost, "UseAWS": false},
+			[]string{"--no-aws"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.NotPanics(t, func() {
-				app := NewTestApplication(tt.args)
+				os.Setenv(envArgs, tt.tgfArgsEnv)
+				defer os.Unsetenv(envArgs)
+				app := NewTestApplication(tt.args, false)
 				config := &TGFConfig{
 					tgf: app,
 					Aliases: map[string]string{

--- a/config_test.go
+++ b/config_test.go
@@ -95,7 +95,7 @@ func TestSetConfigDefaultValues(t *testing.T) {
 	`).UnIndent().TrimSpace())
 	ioutil.WriteFile(testTgfConfigFile, tgfConfig, 0644)
 
-	app := NewTestApplication(nil)
+	app := NewTestApplication(nil, true)
 	app.PsPath = testSSMParameterFolder
 	config := InitConfig(app)
 
@@ -144,7 +144,7 @@ func TestTwoLevelsOfTgfConfig(t *testing.T) {
 	tgfConfig := []byte(String(`docker-image-version: 2.0.2`))
 	ioutil.WriteFile(testTgfConfigFile, tgfConfig, 0644)
 
-	app := NewTestApplication(nil)
+	app := NewTestApplication(nil, true)
 	app.PsPath = testSSMParameterFolder
 	config := InitConfig(app)
 
@@ -169,7 +169,7 @@ func TestWeirdDirName(t *testing.T) {
 	`).UnIndent().TrimSpace())
 	ioutil.WriteFile(testTgfConfigFile, tgfConfig, 0644)
 
-	app := NewTestApplication(nil)
+	app := NewTestApplication(nil, true)
 	app.PsPath = testSSMParameterFolder
 	config := InitConfig(app)
 

--- a/docker_test.go
+++ b/docker_test.go
@@ -82,7 +82,7 @@ func TestGetImage(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert.NotPanics(t, func() {
-				app := NewTestApplication(nil)
+				app := NewTestApplication(nil, true)
 				tt.config.tgf = app
 				app.DockerBuild = tt.dockerBuild
 				app.Refresh = tt.refresh


### PR DESCRIPTION
Currently, args are appended after the --, so they are passed down to terragrunt