### PR TITLE
Avoid asking MFA twice

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -63,7 +63,7 @@ func TestCheckVersionRange(t *testing.T) {
 
 func TestSetConfigDefaultValues(t *testing.T) {
 	// We must reset the cached AWS config check since it could have been modified by another test
-	cachedAWSConfigExistCheck = nil
+	resetCache()
 	tempDir, _ := filepath.EvalSymlinks(must(ioutil.TempDir("", "TestGetConfig")).(string))
 	currentDir, _ := os.Getwd()
 	assert.NoError(t, os.Chdir(tempDir))

--- a/docker.go
+++ b/docker.go
@@ -163,7 +163,11 @@ func (docker *dockerConfig) call() int {
 		if log.GetLevel() >= logrus.DebugLevel {
 			exportedVariables := make(collections.StringArray, len(config.Environment))
 			for i, key := range collections.AsDictionary(config.Environment).KeysAsString() {
-				exportedVariables[i] = String(fmt.Sprintf("%s = %s", key, config.Environment[key.String()]))
+				if key == "AWS_SECRET_ACCESS_KEY" || key == "AWS_SESSION_TOKEN" {
+					exportedVariables[i] = String(fmt.Sprintf("%s = ******", key))
+				} else {
+					exportedVariables[i] = String(fmt.Sprintf("%s = %s", key, config.Environment[key.String()]))
+				}
 			}
 			log.Debugf("Environment variables\n%s", color.HiBlackString(exportedVariables.Join("\n").IndentN(4).Str()))
 		}

--- a/go.mod
+++ b/go.mod
@@ -19,5 +19,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/Microsoft/go-winio v0.4.15 // indirect
-	github.com/aws/aws-sdk-go v1.36.0
+	github.com/aws/aws-sdk-go v1.36.1
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/coveooss/gotemplate/v3 v3.6.0
 	github.com/coveooss/multilogger v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
-github.com/aws/aws-sdk-go v1.36.0 h1:CscTrS+szX5iu34zk2bZrChnGO/GMtUYgMK1Xzs2hYo=
-github.com/aws/aws-sdk-go v1.36.0/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go v1.36.1 h1:rDgSL20giXXu48Ycx6Qa4vWaNTVTltUl6vA73ObCSVk=
+github.com/aws/aws-sdk-go v1.36.1/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=


### PR DESCRIPTION
- Prevent debug trace to display the secrets
- Find the maximum session duration associated with a role
- Automatically extend session time if badly configured
- Hide the MFA (while is not so secret, act as AWS cli does)
- Exit if there is an error when initializing AWS credentials