### PR TITLE
[DT-3603] tgf --with-docker-mount fails with permission denied on Mac hosts

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -93,7 +93,7 @@ func (docker *dockerConfig) call() int {
 	dockerArgs = append(dockerArgs, "-v", fmt.Sprintf("%s%s:/%s", convertDrive(currentDrive), rootFolder, app.MountPoint), "-w", sourceFolder)
 
 	if app.WithDockerMount {
-		withDockerMountArgs := []string{"-v", fmt.Sprintf(dockerSocketMountPattern, dockerSocketFile), "--group-add", getDockerGroup()}
+		withDockerMountArgs := getDockerMountArgs()
 		dockerArgs = append(dockerArgs, withDockerMountArgs...)
 	}
 

--- a/docker_darwin.go
+++ b/docker_darwin.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+)
+
+func getDockerMountArgs() []string {
+	// MacOS has peculiar permissions, so mounting /var/run/docker.sock doesn't work.
+	// See: https://github.com/docker/for-mac/issues/4755#issuecomment-726351209
+	// We mount the raw socket directly from the VM, which has group 'root' in the VM, so we add this group to the user.
+	return []string{"-v", getDockerSocketMount(), "--group-add", "root"}
+}
+
+func getDockerSocketMount() string {
+	return fmt.Sprintf("%[1]s.raw:%[1]s", dockerSocketFile)
+}

--- a/docker_unix.go
+++ b/docker_unix.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 package main
 
@@ -9,6 +9,14 @@ import (
 )
 
 const dockerSocketMountPattern = "%[1]s:%[1]s"
+
+func getDockerMountArgs() []string {
+	return []string{"-v", getDockerSocketMount(), "--group-add", getDockerGroup()}
+}
+
+func getDockerSocketMount() string {
+	return fmt.Sprintf(dockerSocketMountPattern, dockerSocketFile)
+}
 
 func getDockerGroup() string {
 	s := must(os.Stat(dockerSocketFile)).(os.FileInfo)

--- a/docker_windows.go
+++ b/docker_windows.go
@@ -2,6 +2,14 @@ package main
 
 const dockerSocketMountPattern = "/%[1]s:%[1]s"
 
+func getDockerMountArgs() []string {
+	return []string{"-v", getDockerSocketMount(), "--group-add", getDockerGroup()}
+}
+
+func getDockerSocketMount() string {
+	return fmt.Sprintf(dockerSocketMountPattern, dockerSocketFile)
+}
+
 func getDockerGroup() string {
 	return "root"
 }


### PR DESCRIPTION
See DT-3603.

Running docker in an image with tgf that mounts /var/run/docker.sock doesn't work.
See this for an explanation: https://github.com/docker/for-mac/issues/4755#issuecomment-726351209

A solution that works is to mount the raw socket that is available directly in the hyperkit VM.  The user in the image must have the same group as that socket, as it appears in the image (not as it is on the mac host).  I reset my docker for Mac to factory settings and verified that the socket unfortunately has group "root" (not "docker" like on linux or "daemon" like on the Mac host).  So I hard-coded this group in the solution.  Not very pretty, but it works.
