### PR TITLE
[DT-3777] error loading a local config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,3 +369,9 @@ Builds are automatically launched on tagging.
 
 Tags with the format image-0.0.0 automatically launch a Docker images build that are available through Docker Hub.
 Tags with the format v0.0.0 automatically launch a new release on Github for the TGF executable.
+
+Tests that involve docker builds are not compatible with docker buildkit.  Run them with:
+
+```bash
+DOCKER_BUILDKIT=0 go test ./...
+```

--- a/config.go
+++ b/config.go
@@ -524,7 +524,7 @@ func (config *TGFConfig) findRemoteConfigFiles(location, files string) []string 
 		log.Debugln("Reading configuration from", fullConfigPath)
 		source := must(getter.Detect(fullConfigPath, must(os.Getwd()).(string), getter.Detectors)).(string)
 
-		err := getter.Get(destConfigPath, source)
+		err := getter.GetFile(destConfigPath, source)
 		if err == nil {
 			_, err = os.Stat(destConfigPath)
 			if os.IsNotExist(err) {


### PR DESCRIPTION
Loading a local TGFConfig file with a command such as:
`tgf --no-aws --config-location=./configuration/tgf-config`

would result in an error like the following:
file://....../configuration/tgf-config/TGFConfig': source path must be a directory

This change fixes this.
I tested it manually and it works both for a local file, and with a file on aws (i.e. running `tgf` without any options)