### PR TITLE
[DT-3750] Add --config-dump option

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,9 +369,3 @@ Builds are automatically launched on tagging.
 
 Tags with the format image-0.0.0 automatically launch a Docker images build that are available through Docker Hub.
 Tags with the format v0.0.0 automatically launch a new release on Github for the TGF executable.
-
-Tests that involve docker builds are not compatible with docker buildkit.  Run them with:
-
-```bash
-DOCKER_BUILDKIT=0 go test ./...
-```

--- a/cli.go
+++ b/cli.go
@@ -165,7 +165,7 @@ func NewTGFApplication(args []string) *TGFApplication {
 	app.Flag("ssm-path", "Parameter Store path used to find AWS common configuration shared by a team").PlaceHolder("<path>").Default(defaultSSMParameterFolder).StringVar(&app.PsPath)
 	app.Flag("config-files", "Set the files to look for (default: "+remoteDefaultConfigPath+")").PlaceHolder("<files>").StringVar(&app.ConfigFiles)
 	app.Flag("config-location", "Set the configuration location").PlaceHolder("<path>").StringVar(&app.ConfigLocation)
-	app.Flag("config-dump", "Print the TGF configuration and exit.").BoolVar(&app.ConfigDump)
+	app.Flag("config-dump", "Print the TGF configuration and exit").BoolVar(&app.ConfigDump)
 	app.Flag("update", "Run auto update script").IsSetByUser(&app.AutoUpdateSet).BoolVar(&app.AutoUpdate)
 
 	kingpin.CommandLine = app.Application

--- a/cli.go
+++ b/cli.go
@@ -89,7 +89,6 @@ type TGFApplication struct {
 	ConfigLocation       string
 	ConfigDump           bool
 	DisableUserConfig    bool
-	DisableCredsConfig   bool
 	DockerBuild          bool
 	DockerInteractive    bool
 	DockerOptions        []string
@@ -161,7 +160,6 @@ func NewTGFApplication(args []string) *TGFApplication {
 	app.Flag("with-current-user", "Runs the docker command with the current user, using the --user arg").Alias("cu").BoolVar(&app.WithCurrentUser)
 	app.Flag("with-docker-mount", "Mounts the docker socket to the image so the host's docker api is usable").Alias("wd", "dm").BoolVar(&app.WithDockerMount)
 	app.Flag("ignore-user-config", "Ignore all tgf.user.config files").Alias("iu", "iuc").NoAutoShortcut().BoolVar(&app.DisableUserConfig)
-	app.Flag("ignore-credentials-config", "Ignore all credentials configuration").BoolVar(&app.DisableCredsConfig)
 	swFlagON("aws", "Use AWS Parameter store to get configuration").BoolVar(&app.UseAWS)
 	app.Flag("profile", "Set the AWS profile configuration to use").Short('P').NoAutoShortcut().PlaceHolder("<AWS profile>").StringVar(&app.AwsProfile)
 	app.Flag("ssm-path", "Parameter Store path used to find AWS common configuration shared by a team").PlaceHolder("<path>").Default(defaultSSMParameterFolder).StringVar(&app.PsPath)
@@ -270,21 +268,5 @@ func (app *TGFApplication) ShowHelp(c *kingpin.ParseContext) error {
 
 // Run execute the application
 func (app *TGFApplication) Run() int {
-	if app.GetCurrentVersion {
-		if version == locallyBuilt {
-			fmt.Println("tgf (built from source)")
-		} else {
-			fmt.Printf("tgf v%s\n", version)
-		}
-		return 0
-	}
-
-	tgfConfig := InitConfig(app)
-
-	if app.ConfigDump {
-		println(tgfConfig.String())
-		return 0
-	}
-
-	return RunWithUpdateCheck(tgfConfig)
+	return RunWithUpdateCheck(InitConfig(app))
 }

--- a/config.go
+++ b/config.go
@@ -276,9 +276,12 @@ func (config *TGFConfig) setDefaultValues() {
 
 	// Fetch SSM configs
 	if config.awsConfigExist() {
-		if err := config.InitAWS(); err != nil {
-			log.Fatal(err)
+		if !config.tgf.DisableCredsConfig {
+			if err := config.InitAWS(); err != nil {
+				log.Fatal(err)
+			}
 		}
+
 		if app.ConfigLocation == "" {
 			values := config.readSSMParameterStore(app.PsPath)
 			app.ConfigLocation = values[remoteConfigLocationParameter]

--- a/config.go
+++ b/config.go
@@ -252,7 +252,10 @@ func (config *TGFConfig) InitAWS() error {
 		"AWS_REGION":            *session.Config.Region,
 	} {
 		os.Setenv(key, value)
-		config.Environment[key] = value
+		if !config.tgf.ConfigDump {
+			// If we are saving the current configuration, we do not want to save the current credentials
+			config.Environment[key] = value
+		}
 	}
 	return nil
 }
@@ -276,10 +279,8 @@ func (config *TGFConfig) setDefaultValues() {
 
 	// Fetch SSM configs
 	if config.awsConfigExist() {
-		if !config.tgf.DisableCredsConfig {
-			if err := config.InitAWS(); err != nil {
-				log.Fatal(err)
-			}
+		if err := config.InitAWS(); err != nil {
+			log.Fatal(err)
 		}
 
 		if app.ConfigLocation == "" {

--- a/config_run.go
+++ b/config_run.go
@@ -31,6 +31,20 @@ func (config *TGFConfig) Run() int {
 		return 1
 	}
 
+	if app.GetCurrentVersion {
+		if version == locallyBuilt {
+			fmt.Println("tgf (built from source)")
+		} else {
+			fmt.Printf("tgf v%s\n", version)
+		}
+		return 0
+	}
+
+	if app.ConfigDump {
+		fmt.Println(config.String())
+		return 0
+	}
+
 	if app.GetAllVersions {
 		if filepath.Base(config.EntryPoint) != "terragrunt" {
 			log.Error("--all-version works only with terragrunt as the entrypoint")

--- a/config_run_test.go
+++ b/config_run_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -51,6 +52,7 @@ func setup(t *testing.T, testFunction func()) string {
 func TestCurrentVersion(t *testing.T) {
 	version = locallyBuilt
 	output := setup(t, func() {
+		log.SetDefaultConsoleHookLevel(logrus.WarnLevel)
 		app := NewTGFApplication([]string{"--current-version"})
 		exitCode := app.Run()
 		assert.Equal(t, 0, exitCode, "exitCode")

--- a/config_run_test.go
+++ b/config_run_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"github.com/coveooss/gotemplate/v3/yaml"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -13,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func setup(t *testing.T, testFunction func()) string {
+func setup(t *testing.T, testFunction func()) (string, string) {
 	// To ensure that the test is not altered by the environment
 	env := os.Environ()
 	os.Clearenv()
@@ -46,12 +47,12 @@ func setup(t *testing.T, testFunction func()) string {
 	testFunction()
 	w.Close()
 	out, _ := ioutil.ReadAll(r)
-	return string(out) + logBuffer.String()
+	return string(out), logBuffer.String()
 }
 
 func TestCurrentVersion(t *testing.T) {
 	version = locallyBuilt
-	output := setup(t, func() {
+	output, _ := setup(t, func() {
 		log.SetDefaultConsoleHookLevel(logrus.WarnLevel)
 		app := NewTGFApplication([]string{"--current-version"})
 		exitCode := app.Run()
@@ -61,10 +62,21 @@ func TestCurrentVersion(t *testing.T) {
 }
 
 func TestAllVersions(t *testing.T) {
-	output := setup(t, func() {
+	_, logOutput := setup(t, func() {
 		app := NewTGFApplication([]string{"--all-versions", "--no-aws", "--ignore-user-config", "--entrypoint=OTHER_FILE"})
 		exitCode := InitConfig(app).Run()
 		assert.Equal(t, 1, exitCode, "exitCode")
 	})
-	assert.Contains(t, output, "ERROR: --all-version works only with terragrunt as the entrypoint\n")
+	assert.Contains(t, logOutput, "ERROR: --all-version works only with terragrunt as the entrypoint\n")
+}
+
+func TestConfigDump_isValidYAML(t *testing.T) {
+	output, _ := setup(t, func() {
+		app := NewTGFApplication([]string{"-L=5", "--config-dump", "--no-aws", "--ignore-user-config", "--entrypoint=OTHER_FILE"})
+		exitCode := InitConfig(app).Run()
+		assert.Equal(t, 0, exitCode, "exitCode")
+	})
+
+	// --config-dump output can be redirected to a file, so it must be valid YAML.
+	assert.NoError(t, yaml.UnmarshalStrict([]byte(output), &TGFConfig{}))
 }

--- a/docker_test.go
+++ b/docker_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestGetImage(t *testing.T) {
 
+	os.Setenv("DOCKER_BUILDKIT", "0") // For docker tests to pass on Mac, docker buildkit must be disabled
 	testImageName := "test-image" + strconv.Itoa(randInt())
 	testTag := "test" + strconv.Itoa(randInt())
 	testImageNameTagged := testImageName + ":" + testTag


### PR DESCRIPTION
* Added a new `--config-dump` option that dumps the TGF configuration and exits.  It also filters out AWS credentials from the environment so the dumped configuration can be used in more contexts and avoids leaking secrets.

Example usage: `tgf --ignore-user-config --config-dump`
