### PR TITLE
[DT-3750] --config-dump output must not contain any logs

### DIFF
--- a/config.go
+++ b/config.go
@@ -277,6 +277,12 @@ func (config *TGFConfig) setDefaultValues() {
 	}
 	configsData := []configData{}
 
+	// --config-dump output must not contain any logs to be valid YAML
+	// so make sure logs go to stderr in this case
+	if config.tgf.ConfigDump {
+		log.SetStdout(os.Stdout)
+	}
+
 	// Fetch SSM configs
 	if config.awsConfigExist() {
 		if err := config.InitAWS(); err != nil {


### PR DESCRIPTION
The output of --config-dump is meant to be redirected to a file as valid YAML.  tgf log messages must therefore not be on stdout when that option is used.