### PR TITLE
DT-4017 // Fix docker in docker buildkit issue

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -130,7 +130,7 @@ func (docker *dockerConfig) call() int {
 		// Fix for Windows containing the domain name in the Username (e.g. ACME\jsmith)
 		// The backslash is not accepted for a Docker volume path
 		splitUsername := strings.Split(username, "\\")
-		username = splitUsername[len(splitUsername) - 1]
+		username = splitUsername[len(splitUsername)-1]
 
 		homePath := fmt.Sprintf("/home/%s", username)
 		dockerArgs = append(dockerArgs,
@@ -167,6 +167,7 @@ func (docker *dockerConfig) call() int {
 	config.Environment["TGF_ARGS"] = strings.Join(os.Args, " ")
 	config.Environment["TGF_LAUNCH_FOLDER"] = sourceFolder
 	config.Environment["TGF_IMAGE_NAME"] = imageName // sha256 of image
+	config.Environment["DOCKER_BUILDKIT"] = "0"
 
 	if !strings.Contains(config.Image, "coveo/tgf") { // the tgf image injects its own image info
 		config.Environment["TGF_IMAGE"] = config.Image


### PR DESCRIPTION
Buildkit seems to make problems when using Docker in Docker. This "fix" simply disables Buildkit directly at the source. 

The root of the problem is that the buildkit deamon is supposed to only run on Linux as per what [Buildkit's own README](https://github.com/moby/buildkit#quick-start) says, but other sources (mostly not the readme) say Buildkit is enabled on Windows and MacOS (Docker for Desktop). My instinct says that when we move into the first layer of docker we loose access to the daemon running on the host and that's what we need to fix (I could be wrong tho).

Further investigation is underway for a more... 😎  sophisticated 😎  fix.