### PR TITLE
Build macOS ARM binaries + update goreleaser

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -17,9 +17,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Build tag
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CGO_ENABLED: 0
-        run: |
-          curl -sL https://git.io/goreleaser | bash;

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,11 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
+
+# Build one binary for Mac OS (arm64 and amd64)
+universal_binaries:
+  - replace: true
 
 # Archive customization
 archives:


### PR DESCRIPTION
- Add `arm64` binaries to build. Those will be made for macOS and Linux
- Allow universal binaries for macOS
- Use a GitHub Action instead of running bash script to run goreleaser