### PR TITLE
Update Go to 1.17 to actually build a mac ARM64 version

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.17
         id: go
 
       - name: Checkout

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,10 +8,10 @@ builds:
     goarch:
       - amd64
       - arm64
-
-# Build one binary for Mac OS (arm64 and amd64)
-universal_binaries:
-  - replace: true
+    ignore:
+      # Windows arm64 is not used and does not compile well as of writing
+      - goos: windows
+        goarch: arm64
 
 # Archive customization
 archives:


### PR DESCRIPTION
Building on older Go versions does not produce ARM64 versions of binaries on Mac and Windows.

Windows ARM64 build is ignored because it does not seem to work and is not used anyway.

I also removed the universal binaries as it would be twice as big for no big reason (in my opinion)