### PR TITLE
Add whole team as reviewers for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,13 @@ updates:
     interval: weekly
   open-pull-requests-limit: 99
   reviewers:
-  - julienduchesne
+  - dblanchette
+  - dlevesque-coveo
+  - dotboris
+  - jocgir
+  - jonapich
+  - pballandras
+  - wtrep
   ignore:
   - dependency-name: github.com/aws/aws-sdk-go
     versions:


### PR DESCRIPTION
It used to be Julien but he's not a collaborator anymore. This will ensure that we see the updates and deal with them.