### PR TITLE
Add renovate shareable config to update TGF

### DIFF
--- a/.github/renovate/README.md
+++ b/.github/renovate/README.md
@@ -1,0 +1,28 @@
+## Renovate preset configuration to update TGF versions
+
+### What is [Renovate](https://docs.renovatebot.com/)?
+
+It's a bot that helps updating dependencies in your repository. Out of the box it supports a lot of packaging types like mvn, npm or docker. They are called managers. 
+
+It supports external configurations they call [preset](https://docs.renovatebot.com/config-presets/).
+
+### What is this preset?
+
+It's a custom dependency manager built with [regex](https://docs.renovatebot.com/modules/manager/regex/) that detects tgf.config files in your repo and updates it with an up to date version tagged from this current repo. 
+
+### How to configure it on your repo
+
+In your Renovate configuration, you have an array name [extends](https://docs.renovatebot.com/configuration-options/#extends). This array allows you to add a shareable configuration preset. Go to https://docs.renovatebot.com/config-presets/#shareable-config-presets to read more about the subject. 
+
+In this example it shows you how you add the tgf-update preset
+```json
+  "extends": [
+    "config:base",
+    "github>coveo/tgf-images-coveo//renovate/preset/tgf"
+  ],
+```
+
+### What kind of PRs should I expect?
+
+You'll have a PR that update your tgf version to the latest version possible whatever the current version you are on. That means your PR build should contains a tgf plan/plan-all command to get any errors before it's packaged to the deployment pipeline.
+

--- a/.github/renovate/tgf.json
+++ b/.github/renovate/tgf.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "separateMinorPatch": true,
+  "logLevel": "debug",
+  "enabledManagers": ["regex"],
+  "packageRules": [
+    {
+      "matchFiles": ["(^|/|\\\\.).tgf.config"],
+      "matchDatasources": ["github-tags"],
+      "matchUpdateTypes": ["major","minor"],
+      "enabled": true,
+      "automerge": false
+    }
+  ],
+  "branchTopic": "{{{depNameSanitized}}}-{{{newMajor}}}.{{{newMinor}}}",
+  "regexManagers": [
+    {
+      "fileMatch": ["(^|/|\\\\.).tgf.config"],
+      "matchStrings": [
+        "docker-image-version: (?<currentValue>.* ?)",
+        "docker-image-version: '(?<currentValue>.* ?)'",
+        "docker-image-version: \"(?<currentValue>.* ?)\""
+      ],
+      "depNameTemplate": "coveo/tgf-images-coveo",
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)?$",
+      "extractVersionTemplate": "^(?<version>\\d+\\.\\d+)"
+    }
+  ]
+}


### PR DESCRIPTION
### Description

The json file is a shareable preset Renovate configuration file. I invite you to read the readme file.
It doesn't trigger renovate on this repo, but does provide a configuration preset for any repo that has a renovate configuration.

I propose to sit this configuration here because I think it would make sense to keep it close to the relevant versioning source.

The way I propose to target the preset it to always target the master branch. Any updates will impact all repository configured with it. This means any changes has to be thoroughly tested.

### Checklist

- [x] Added README.md documentation
- [ ] Added confluence documentation
