### PR TITLE
DT-4621 // Docker passthrough login output

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -535,9 +535,11 @@ func (docker *dockerConfig) tryLoginToECR(image string) error {
 	dockerLoginCmd := exec.Command(
 		"docker", "login", "-u",
 		strings.Split(decodedLogin, ":")[0],
-		"-p", strings.Split(decodedLogin, ":")[1],
+		"--password-stdin",
 		*result.AuthorizationData[0].ProxyEndpoint,
 	)
+	dockerLoginCmd.Stdin = strings.NewReader(strings.Split(decodedLogin, ":")[1])
+	dockerLoginCmd.Stdout, dockerLoginCmd.Stderr = os.Stdout, os.Stderr
 	if err := dockerLoginCmd.Run(); err != nil {
 		return errors.Managed(err.Error())
 	}


### PR DESCRIPTION
We log the stdout and stderr from the docker login CMD. We also removed a warning from the docker login command that appeared with the output.