### PR TITLE
CSEC-18899 bumping goreleaser-action from 3 to 3.2

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0 # goreleaser needs the whole history to build the release notes
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
Bumping goreleaser-action from 3 to 3.2 via hash to comply with CSEC's GHA policy