### PR TITLE
Fix arg parsing when providing long short flags

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -200,12 +200,12 @@ func TestApplicationUnmanagedArgs(t *testing.T) {
 			// This test is a safety to catch if someone adds a -v flag to not break
 			// Terraform "-var" single dash flag. It will crash trying to parse -ar
 			// because the underlying flag parser will consider -var as equivalent to
-			// writing "-v -a -r" and so will try to continue reading "-a" and "-r"
+			// writing "-v -a -r" and so may try to continue reading "-a" and "-r" or
+			// "ar" as a value
 			"[case 1] tgf leaves every argument unmanaged",
 			[]string{"-v", "-a", "-r", "-var", "region=us-west-2", "-auto-approve"},
 			[]string{"-v", "-a", "-r", "-var", "region=us-west-2", "-auto-approve"},
 		},
-		// This one needs the fix in kingpin to work
 		{
 			"[case 2] tgf leaves every argument unmanaged",
 			[]string{"apply", "-auto-approve", "-var", "region=us-west-2"},

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/coveooss/gotemplate/v3 v3.7.3
 	github.com/coveooss/multilogger v0.5.2
-	github.com/coveord/kingpin/v2 v2.4.0
+	github.com/coveord/kingpin/v2 v2.4.1
 	github.com/docker/docker v20.10.21+incompatible
 	github.com/fatih/color v1.13.0
 	github.com/hashicorp/go-getter v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -461,8 +461,9 @@ github.com/coveooss/gotemplate/v3 v3.7.3 h1:Hj+dfLmXFRUNfveUJyqegkxQlCru7gUQG6Tf
 github.com/coveooss/gotemplate/v3 v3.7.3/go.mod h1:9yJD1GLPopmgNfE3Nra6G04yKX8WmQh5HAWE+FC3dQ0=
 github.com/coveooss/multilogger v0.5.2 h1:HmuMT1RTD0d6tkqrrO9FlUBbp2p7QYbcAR6guszlifc=
 github.com/coveooss/multilogger v0.5.2/go.mod h1:Pw3jXW2Y4KEd+j5vFTTGSAFRX4fIOvJZzDPnvf9dr7U=
-github.com/coveord/kingpin/v2 v2.4.0 h1:wU/bzvMIzN9JlN8kxpAUmTKc5MPSVN6mxqReTRNCaw8=
 github.com/coveord/kingpin/v2 v2.4.0/go.mod h1:Qw3FnQuB068XW8vcP58GH4c03MYzCmiK00/yLDfqQA8=
+github.com/coveord/kingpin/v2 v2.4.1 h1:nqqSel2A5VoQp7TR6Q/vGqvwGs0fE7Qwg/RdBmdHSk0=
+github.com/coveord/kingpin/v2 v2.4.1/go.mod h1:Qw3FnQuB068XW8vcP58GH4c03MYzCmiK00/yLDfqQA8=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
Updates kingpin to v2.4.1, [see its release](https://github.com/coveord/kingpin/releases/tag/v2.4.1).

tl;dr

Fixes the use of "long short flags" that exist in some applications like Terraform's -auto-approve.

Before it would read `-auto-approve` as `-a -u -t -o` and fail at the middle `-` because it would find a long flag `--approve`. Now we catch those cases and handle them.

## But wait, there's more

Also adds tests so that we don't eat flags we aren't supposed to