### PR TITLE
Add message to warn users about default install path

### DIFF
--- a/get-latest-tgf.sh
+++ b/get-latest-tgf.sh
@@ -14,7 +14,7 @@ if [ ! -w "${TGF_PATH}" ]; then
     echo "System installation directory ${TGF_PATH} is not writeable."
     if [[ "$OSTYPE" == "darwin"* && "${TGF_PATH}" == "${DEFAULT_INSTALL_DIR}" ]]; then
         # Mac OSX
-        echo "Since MacOS Ventura (13.X), the default install path is owned by 'root'."
+        echo "Since MacOS Ventura (13.X), $TGF_PATH is owned by 'root'."
         echo "You can fix this by either"
         echo "  1. Running 'sudo chown -R $(id -un):$(id -gn) $TGF_PATH'."
         echo "  2. Setting the TGF_PATH variable to an alternate, writable directory."


### PR DESCRIPTION
Starting with MacOS Ventura (13.X), the `/usr/local/bin` folder is owned by root on new installs.

This aims to clarify to users with new macs what is going on and guide them when the installer fails.

This PR adds:

- A warning to Mac users specifically that have not changed the install path. This aims at catching the error case that will probably happen often moving forward.
- Two possible solutions

This PR doesn't add:

- A real fix: We can't fix that Apple changed the rights on a folder. Instead we give more information.
- The execution of the solution. We leave the user to decide what solution he wants to apply.