### PR TITLE
Fetch latest TGF release from GH API for install scripts

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  test-install-posix:
+  posix:
     strategy:
       matrix:
         os: [ macos-latest, ubuntu-latest ]
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: ./get-latest-tgf.sh
 
-  test-install-windows:
+  windows:
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -1,23 +1,27 @@
-name: Test TGF installation
+name: Test Install
 
 on:
   pull_request:
     branches:
       - master
-jobs:
-  build:
-    name: Install
 
+jobs:
+  test-install-posix:
     strategy:
       matrix:
         os: [ macos-latest, ubuntu-latest ]
-
     runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - run: ./get-latest-tgf.sh
+
+  test-install-windows:
+    runs-on: windows-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Install TGF
-        run: |
-          ./get-latest-tgf.sh
+        run: ./get-latest-tgf.ps1

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -20,8 +20,5 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install TGF
-        run: ./get-latest-tgf.ps1
+      - uses: actions/checkout@v3
+      - run: ./get-latest-tgf.ps1

--- a/get-latest-tgf.ps1
+++ b/get-latest-tgf.ps1
@@ -9,8 +9,9 @@ try {
         # It considers the redirect http codes errors. Ignore that.
         SkipHttpErrorCheck = $true
         # The missed redirect generates an actual error which stops the program. We ignore it.
-        ErrorAction = "Continue"
+        ErrorAction = "SilentlyContinue"
     }
+
     $latestReleaseUrl = (Invoke-WebRequest @latestReleaseRequest).Headers["Location"]
     $LATEST_VERSION = $latestReleaseUrl.Split("/")[-1].TrimStart("v")
     Write-Host "- tgf version (latest):" $LATEST_VERSION

--- a/get-latest-tgf.ps1
+++ b/get-latest-tgf.ps1
@@ -1,8 +1,8 @@
 $ErrorActionPreference = "Stop" #Make all errors terminating
 
 try {
-    $bVersion = (Invoke-WebRequest -Uri "https://coveo-bootstrap-us-east-1.s3.amazonaws.com/tgf_version.txt").Content
-    $LATEST_VERSION = [System.Text.Encoding]::ASCII.GetString($bVersion)
+    $latestRelease = (Invoke-WebRequest -Uri "https://api.github.com/repos/coveooss/tgf/releases/latest" | ConvertFrom-Json)
+    $LATEST_VERSION = $latestRelease.tag_name.TrimStart("v")
     Write-Host "- tgf version (latest):" $LATEST_VERSION
 } catch {
     Write-Host Error fetching latest version

--- a/get-latest-tgf.ps1
+++ b/get-latest-tgf.ps1
@@ -1,8 +1,18 @@
 $ErrorActionPreference = "Stop" #Make all errors terminating
 
 try {
-    $latestRelease = (Invoke-WebRequest -Uri "https://api.github.com/repos/coveooss/tgf/releases/latest" | ConvertFrom-Json)
-    $LATEST_VERSION = $latestRelease.tag_name.TrimStart("v")
+    $latestReleaseRequest = @{
+        Method = "HEAD"
+        Uri = "https://github.com/coveooss/tgf/releases/latest"
+        # Prevent redirect. We want the Location header.
+        MaximumRedirection = 0
+        # It considers the redirect http codes errors. Ignore that.
+        SkipHttpErrorCheck = $true
+        # The missed redirect generates an actual error which stops the program. We ignore it.
+        ErrorAction = "Continue"
+    }
+    $latestReleaseUrl = (Invoke-WebRequest @latestReleaseRequest).Headers["Location"]
+    $LATEST_VERSION = $latestReleaseUrl.Split("/")[-1].TrimStart("v")
     Write-Host "- tgf version (latest):" $LATEST_VERSION
 } catch {
     Write-Host Error fetching latest version

--- a/get-latest-tgf.sh
+++ b/get-latest-tgf.sh
@@ -50,7 +50,7 @@ get_latest_tgf_version () {
             | sed 's/^v//'
     )"
 
-    if [ -e "$TGF_LATEST_VERSION" ]
+    if [ -z "$TGF_LATEST_VERSION" ]
     then
         echo "Could not obtain tgf latest version."
         exit 1


### PR DESCRIPTION
Currently the install scripts rely on a text file hosted on AWS S3 which holds the latest release of TGF. The link between this file and the latest release on GH is managed by some infrastructure at Coveo. We would like to get rid of that infrastructure.

To allow that, this PR changes the install scripts so that they query the GitHub API to figure out what the latest release is. This matches the behaviour of the auto-update feature within TGF itself.