### PR TITLE
Fix goreleaser & revamp CI & repo in general

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,13 +16,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Go
-        uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.17
-
-      - name: Checkout
-        uses: actions/checkout@v3
 
       - uses: coveooss/configure-aws-credentials-action@v1.7.0
         with:
@@ -38,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.17
 
@@ -54,7 +51,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # goreleaser needs the whole history to build the release notes
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.17
 
@@ -69,7 +66,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: test-release
-          path:
+          path: |
             dist/*.zip
             dist/*.txt
           if-no-files-found: error

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,10 +3,10 @@ on:
   pull_request:
     branches:
       - master
-jobs:
-  build:
-    name: Test
+      - main
 
+jobs:
+  test:
     permissions:
       id-token: write # required for AWS assume role
 
@@ -20,7 +20,6 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.17
-        id: go
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -34,3 +33,44 @@ jobs:
         env:
           AWS_REGION: us-east-1
         run: go test -v ./...
+
+  goreleaser-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+
+      - uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757
+        with:
+          distribution: goreleaser
+          version: latest
+          args: check
+
+  goreleaser-test-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # goreleaser needs the whole history to build the release notes
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+
+      - uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --snapshot --clean
+        env:
+          CGO_ENABLED: 0
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: test-release
+          path:
+            dist/*.zip
+            dist/*.txt
+          if-no-files-found: error
+          retention-days: 5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           go-version: 1.17
 
-      - uses: coveooss/configure-aws-credentials-action@v1.7.0
+      - uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::043612128888:role/nrd-oss-tgf-github-actions-ci

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -8,7 +8,7 @@ jobs:
     name: Tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.17
       - uses: actions/checkout@v3

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,26 +1,21 @@
-name: Build
+name: Release on Tag
 on:
   push:
     tags:
       - "v*"
 jobs:
-  build:
+  release:
     name: Tag
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Go
-        uses: actions/setup-go@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.17
-        id: go
-
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # goreleaser needs the whole history to build the release notes
 
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757
+      - uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CGO_ENABLED: 0

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - main
 
 jobs:
   posix:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,5 +29,4 @@ archives:
 
 # GitHub release customization
 release:
-  draft: true
   prerelease: auto

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,10 +16,13 @@ builds:
 # Archive customization
 archives:
   - format: zip
-
-    replacements:
-      amd64: 64-bits
-      darwin: macOS
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- if eq .Os "darwin" }}macOS_
+      {{- else }}{{ .Os }}_{{ end }}
+      {{- if eq .Arch "amd64" }}64-bits
+      {{- else }}{{ .Arch }}{{ end }}
 
     files:
       - nothing.*
@@ -27,4 +30,4 @@ archives:
 # GitHub release customization
 release:
   draft: true
-  prerelease: true
+  prerelease: auto

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @coveooss/dev-tooling

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+## Release procedure
+
+1. Find the latest tag
+1. Look at changes between now and the current tag
+1. Create a tag with the format `vX.Y.Z`
+
+    You might be tempted to create a release through GitHub to create the tag.
+    Don't do that. We have a GitHub workflow in place that will create a release
+    from tags that get pushed. Create your tag with `git tag`.
+
+1. Push that tag
+1. Wait for the [Release on Tag](https://github.com/coveooss/tgf/actions/workflows/tag.yml) to build your release.
+1. Find your release and make sure things are as you expect them to be

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ outdated version.
 
 ## Installation
 
-On `mac` and `linux`:  
+On `mac` and `linux`:
 
 You can run the `get-latest-tgf.sh` script to check if you have the latest version of tgf installed and install it as needed:
 
@@ -362,10 +362,3 @@ Start a shell `fish` in the current folder
 
 Invokes `my_command` in your own docker image. As you can see, you can do whatever you need to with `tgf`. It is not restricted to only the pre-packaged
 Docker images, you can use it to run any program in any Docker images. Your imagination is your limit.
-
-## Development
-
-Builds are automatically launched on tagging.
-
-Tags with the format image-0.0.0 automatically launch a Docker images build that are available through Docker Hub.
-Tags with the format v0.0.0 automatically launch a new release on Github for the TGF executable.


### PR DESCRIPTION
The release is all broken because goreleaser was updated but we didn't migrate the config.

At least that's how it started. I realized that this repo was in need of some love so I did the following:
- Configure `goreleaser` to publish the releases it creates. Having to publish it manually is easy to forget and plain old busywork.
- Add `goreleaser` to the CI
- Clean up existing workflows (simplify names & remove redundant bits)
- Migrate from `goreleaser release ... --rm-dist` to `goreleaser relrease ... --clean`
- Update `actions/setup-go` to v4 (we get caching for free 🎉)
- Use the official action for setting up aws creds (includes a bump to v2). We don't need our fork anymore.
- Document the release process
- Add @coveooss/dev-tooling as code owners of the repo