### PR TITLE
Update get-latest-tgf.ps1 script to require PowerShell 7 or higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can run the `get-latest-tgf.sh` script to check if you have the latest versi
 curl https://raw.githubusercontent.com/coveooss/tgf/master/get-latest-tgf.sh | bash
 ```
 
-On `Windows`, run `get-latest-tgf.ps1` with Powershell:
+On `Windows`, run `get-latest-tgf.ps1` with Powershell (version 7.x or more):
 
 ```PowerShell
 (Invoke-WebRequest https://raw.githubusercontent.com/coveooss/tgf/master/get-latest-tgf.ps1).Content | Invoke-Expression

--- a/get-latest-tgf.ps1
+++ b/get-latest-tgf.ps1
@@ -1,5 +1,11 @@
 $ErrorActionPreference = "Stop" #Make all errors terminating
 
+# This script uses Powershell 7 features. Make sure we are running in Powershell 7.
+if ($PSVersionTable.PSVersion.Major -lt 7) {
+    Write-Host "The tgf install script requires PowerShell 7 or higher. Please install PowerShell 7 and try again."
+    Exit 1
+}
+
 try {
     $latestReleaseRequest = @{
         Method = "HEAD"


### PR DESCRIPTION
This PR introduces a version check at the beginning of the `get-latest-tgf.ps1` script to ensure that it is being run with `PowerShell` 7 or higher. It also updates the `README` to indicate that version 7 or higher of `Powershell` is needed.