### PR TITLE
bootstrap from config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
 
 # Archive customization
 archives:
-  - format: zip
+  - formats: zip
     name_template: >-
       {{ .ProjectName }}_
       {{- .Version }}_

--- a/README.md
+++ b/README.md
@@ -90,15 +90,18 @@ You can specify multiple files in `config-paths` by separating them with `:` (e.
 TGF will attempt to use the [AWS parameter store](https://aws.amazon.com/ec2/systems-manager/parameter-store/).
 The `ssm-path` (default: `/default/tgf`) is the location of the configuration keys `config-location` and `config-paths`.
 
-If no `config-location` is found, it will look directly in SSM for configuration keys (ex: `/default/tgf/logging-level`).
-
 **Note**: The SSM configuration will only be read if AWS environment variables are set, the AWS CLI is installed or the ~/.aws folder exists. If you wish to force TGF to read the SSM config and these conditions are not met, you can set the `TGF_USE_AWS_CONFIG=true` environment variable
 
-### 2. The local config pass
+### 2. The config pass
 
-TGF will look for `.tgf.config` and `tgf.user.config` again. This time, all remaining parameters are considered.
+TGF will attempt to find the `config-paths` in `config-location`.
+
+If no config files can be found at `config-location`, it will look directly in SSM for configuration keys (ex: `/default/tgf/logging-level`).
+Otherwise said, if you want to load defaults from SSM directly, do not set `config-location`.
+
+TGF will when look for `.tgf.config` and `tgf.user.config` again in the working directory and parents.
+This time, all remaining parameters are considered.
 These configuration files overwrite the remote configurations.
-
 
 Example of a YAML configuration file:
 

--- a/README.md
+++ b/README.md
@@ -63,19 +63,49 @@ On `Windows`, run `get-latest-tgf.ps1` with Powershell (version 7.x or more):
 
 ## Configuration
 
-TGF has multiple levels of configuration. It first looks through the [AWS parameter store](https://aws.amazon.com/ec2/systems-manager/parameter-store/)
-under `/default/tgf` using your current [AWS CLI configuration](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) if any. There, it tries to find parameters called `config-location` (example: bucket.s3.amazonaws.com/foo) and `config-paths` (example: my-file.json:my-second-file.json, default: TGFConfig). If it finds `config-location`, it fetches its config from that path using the [go-getter library](https://github.com/hashicorp/go-getter). Otherwise, it looks directly in SSM for configuration keys (ex: `/default/tgf/logging-level`).
+TGF has multiple levels of configuration. 
+
+TGF looks for a file named `.tgf.config` or `tgf.user.config` in the current working folder (and recursively in any parent folders).
+Your configuration file should be expressed in [YAML](http://www.yaml.org/start.html), [JSON](http://www.json.org/) or [HCL](https://developer.hashicorp.com/packer/docs/templates/hcl_templates/syntax).
+
+### 1. The bootstrap pass
+
+During the bootstrap pass, only the following parameters are considered:
+
+- config-location
+- config-paths
+- ssm-path
+
+
+#### If `config-location` is set
+
+If `config-location` is set (either using `--config-location` or through a config file), tgf will attempt to load the configuration from there.
+Many locations are supported (e.g.: `bucket.s3.amazonaws.com/foo`): see [go-getter library](https://github.com/hashicorp/go-getter).
+
+The filename to load will be determined by the `config-paths` argument (default: `TGFConfig`).
+You can specify multiple files in `config-paths` by separating them with `:` (e.g.: `my-file.json:my-second-file.json`).
+
+#### If `config-location` is *not* set
+
+TGF will attempt to use the [AWS parameter store](https://aws.amazon.com/ec2/systems-manager/parameter-store/).
+The `ssm-path` (default: `/default/tgf`) is the location of the configuration keys `config-location` and `config-paths`.
+
+If no `config-location` is found, it will look directly in SSM for configuration keys (ex: `/default/tgf/logging-level`).
 
 **Note**: The SSM configuration will only be read if AWS environment variables are set, the AWS CLI is installed or the ~/.aws folder exists. If you wish to force TGF to read the SSM config and these conditions are not met, you can set the `TGF_USE_AWS_CONFIG=true` environment variable
 
-TGF then looks for a file named .tgf.config or tgf.user.config in the current working folder (and recursively in any parent folders) to get its parameters. These configuration files overwrite the remote configurations.
-Your configuration file could be expressed in  [YAML](http://www.yaml.org/start.html) or [JSON](http://www.json.org/).
+### 2. The local config pass
+
+TGF will look for `.tgf.config` and `tgf.user.config` again. This time, all remaining parameters are considered.
+These configuration files overwrite the remote configurations.
+
 
 Example of a YAML configuration file:
 
 ```yaml
 docker-refresh: 1h
 logging-level: notice
+config-location: bucket.s3.amazonaws.com/foo
 ```
 
 Example of a JSON configuration file:
@@ -83,7 +113,8 @@ Example of a JSON configuration file:
 ```json
 {
   "docker-refresh": "1h",
-  "logging-level": "notice"
+  "logging-level": "notice",
+  "config-location": "bucket.s3.amazonaws.com/foo"
 }
 ```
 
@@ -91,6 +122,9 @@ Example of a JSON configuration file:
 
 Key | Description | Default value
 --- | --- | ---
+config-location | (bootstrap variable) Location where the configuration files are located | *no default*
+config-paths | (bootstrap variable) List of configuration files to look for (separated by `:`) | TGFConfig
+ssm-path | (bootstrap variable) Parameter Store path used to find AWS common configuration shared by a team | /default/tgf
 docker-image | Identify the docker image  to use | coveo/tgf
 docker-image-version | Identify the image version | *no default*
 docker-image-tag | Identify the image tag (could specify specialized version such as k8s, full) | latest
@@ -107,7 +141,7 @@ run-before | Script that is executed before the actual command | *no default*
 run-after | Script that is executed after the actual command | *no default*
 alias | Allows to set short aliases for long commands<br>`my_command: "--ri --with-docker-mount --image=my-image --image-version=my-tag -E my-script.py"` | *no default*
 auto-update | Toggles the auto update check. Will only perform the update after the delay | true
-auto-update-delay | Delay before running auto-update again  | 2h (2 hours)
+auto-update-delay | Delay before running auto-update again | 2h (2 hours)
 update-version | The version to update to when running auto update | Latest fetched from Github's API
 
 Note: *The key names are not case-sensitive*

--- a/cli.go
+++ b/cli.go
@@ -83,7 +83,7 @@ const (
 type TGFApplication struct {
 	*kingpin.Application
 	AwsProfile           string
-	ConfigFiles          string
+	ConfigFiles          string // pretty much called `config-paths` everywhere but here...
 	ConfigLocation       string
 	ConfigDump           bool
 	DisableUserConfig    bool
@@ -163,6 +163,7 @@ func NewTGFApplication(args []string) *TGFApplication {
 	app.Flag("profile", "Set the AWS profile configuration to use").Short('P').NoAutoShortcut().PlaceHolder("<AWS profile>").StringVar(&app.AwsProfile)
 	app.Flag("ssm-path", "Parameter Store path used to find AWS common configuration shared by a team").PlaceHolder("<path>").Default(defaultSSMParameterFolder).StringVar(&app.PsPath)
 	app.Flag("config-files", "Set the files to look for (default: "+remoteDefaultConfigPath+")").PlaceHolder("<files>").StringVar(&app.ConfigFiles)
+	app.Flag("config-paths", "(alias for --config-files)").PlaceHolder("<files>").StringVar(&app.ConfigFiles)
 	app.Flag("config-location", "Set the configuration location").PlaceHolder("<path>").StringVar(&app.ConfigLocation)
 	app.Flag("config-dump", "Print the TGF configuration and exit").BoolVar(&app.ConfigDump)
 	app.Flag("update", "Run auto update script").IsSetByUser(&app.AutoUpdateSet).BoolVar(&app.AutoUpdate)

--- a/config.go
+++ b/config.go
@@ -337,16 +337,16 @@ func (config *TGFConfig) InitAWS() error {
 	return nil
 }
 
-// Temporary structure to hold app.PsPath, app.ConfigLocation, app.ConfigPaths
+// We use this structure to keep track of the config sources and their content separately
 type configData struct {
 	Name   string
 	Raw    string
 	Config *TGFConfig
 }
 
-// setConfigLocationFromLocalFiles will read the local config files
+// setBootstrapVariablesFromLocalFiles will read the local config files
 // and attempt to set the config-location, config-paths and ssm-path values.
-func (config *TGFConfig) setConfigLocationFromLocalFiles() {
+func (config *TGFConfig) setBootstrapVariablesFromLocalFiles() {
 	app := config.tgf
 	for _, configFile := range config.findConfigFiles(must(os.Getwd()).(string)) {
 		log.Debugln("Reading bootstrap configuration from", configFile)
@@ -368,7 +368,7 @@ func (config *TGFConfig) setConfigLocationFromLocalFiles() {
 		if app.ConfigFiles == "" && localConfig.ConfigPaths != "" {
 			app.ConfigFiles = localConfig.ConfigPaths
 		}
-		if (app.PsPath == defaultSSMParameterFolder || app.PsPath == "") && localConfig.SSMPath != "" {
+		if app.PsPath == defaultSSMParameterFolder && localConfig.SSMPath != "" {
 			app.PsPath = localConfig.SSMPath
 		}
 	}
@@ -391,8 +391,8 @@ func (config *TGFConfig) setDefaultValues() {
 		log.SetStdout(os.Stdout)
 	}
 
-	// First read local config files; this allows bootstrapping values earlier.
-	config.setConfigLocationFromLocalFiles()
+	// First, read local config files for bootstrap variables.
+	config.setBootstrapVariablesFromLocalFiles()
 
 	// Fetch SSM configs
 	if config.awsConfigExist() {

--- a/config.go
+++ b/config.go
@@ -349,7 +349,7 @@ type configData struct {
 func (config *TGFConfig) setConfigLocationFromLocalFiles() {
 	app := config.tgf
 	for _, configFile := range config.findConfigFiles(must(os.Getwd()).(string)) {
-		log.Debugln("Reading configuration from", configFile)
+		log.Debugln("Reading bootstrap configuration from", configFile)
 		readBytes, err := os.ReadFile(configFile)
 		content := string(readBytes)
 
@@ -362,13 +362,13 @@ func (config *TGFConfig) setConfigLocationFromLocalFiles() {
 			log.Errorf("Error while loading configuration from %s\nConfiguration file must be valid YAML, JSON or HCL\n%v\nContent:\n%s", configFile, err, content)
 			continue
 		}
-		if localConfig.ConfigLocation != "" {
+		if app.ConfigLocation == "" && localConfig.ConfigLocation != "" {
 			app.ConfigLocation = localConfig.ConfigLocation
 		}
-		if localConfig.ConfigFiles != "" {
+		if app.ConfigFiles == "" && localConfig.ConfigFiles != "" {
 			app.ConfigFiles = localConfig.ConfigFiles
 		}
-		if localConfig.SSMPath != "" {
+		if (app.PsPath == defaultSSMParameterFolder || app.PsPath == "") && localConfig.SSMPath != "" {
 			app.PsPath = localConfig.SSMPath
 		}
 	}

--- a/config.go
+++ b/config.go
@@ -345,7 +345,7 @@ type configData struct {
 }
 
 // setConfigLocationFromLocalFiles will read the local config files
-// and attempt to set the config-location, config-files and ssm-path values.
+// and attempt to set the config-location, config-paths and ssm-path values.
 func (config *TGFConfig) setConfigLocationFromLocalFiles() {
 	app := config.tgf
 	for _, configFile := range config.findConfigFiles(must(os.Getwd()).(string)) {

--- a/config.go
+++ b/config.go
@@ -78,6 +78,13 @@ type TGFConfig struct {
 	tgf                                 *TGFApplication
 }
 
+// TGFConfigBootstrap contains an entry specifying how to bootstrap the configuration
+type TGFConfigBootstrap struct {
+	ConfigLocation string `yaml:"config-location,omitempty" json:"config-location,omitempty" hcl:"config-location,omitempty"`
+	ConfigFiles    string `yaml:"config-files,omitempty" json:"config-files,omitempty" hcl:"config-files,omitempty"`
+	SSMPath        string `yaml:"ssm-path,omitempty" json:"ssm-path,omitempty" hcl:"ssm-path,omitempty"`
+}
+
 // TGFConfigBuild contains an entry specifying how to customize the current docker image
 type TGFConfigBuild struct {
 	Instructions string
@@ -330,6 +337,43 @@ func (config *TGFConfig) InitAWS() error {
 	return nil
 }
 
+// Temporary structure to hold app.PsPath, app.ConfigLocation, app.ConfigFiles
+type configData struct {
+	Name   string
+	Raw    string
+	Config *TGFConfig
+}
+
+// setConfigLocationFromLocalFiles will read the local config files
+// and attempt to set the config-location, config-files and ssm-path values.
+func (config *TGFConfig) setConfigLocationFromLocalFiles() {
+	app := config.tgf
+	for _, configFile := range config.findConfigFiles(must(os.Getwd()).(string)) {
+		log.Debugln("Reading configuration from", configFile)
+		readBytes, err := os.ReadFile(configFile)
+		content := string(readBytes)
+
+		if err != nil {
+			log.Errorf("Error while loading configuration file %s\n%v", configFile, err)
+			continue
+		}
+		localConfig := TGFConfigBootstrap{}
+		if err := collections.ConvertData(content, &localConfig); err != nil {
+			log.Errorf("Error while loading configuration from %s\nConfiguration file must be valid YAML, JSON or HCL\n%v\nContent:\n%s", configFile, err, content)
+			continue
+		}
+		if localConfig.ConfigLocation != "" {
+			app.ConfigLocation = localConfig.ConfigLocation
+		}
+		if localConfig.ConfigFiles != "" {
+			app.ConfigFiles = localConfig.ConfigFiles
+		}
+		if localConfig.SSMPath != "" {
+			app.PsPath = localConfig.SSMPath
+		}
+	}
+}
+
 // setDefaultValues sets the uninitialized values from the config files and the parameter store
 // Priorities (Higher overwrites lower values):
 // 1. Configuration location files
@@ -339,12 +383,6 @@ func (config *TGFConfig) InitAWS() error {
 func (config *TGFConfig) setDefaultValues() {
 	app := config.tgf
 
-	//app.PsPath, app.ConfigLocation, app.ConfigFiles
-	type configData struct {
-		Name   string
-		Raw    string
-		Config *TGFConfig
-	}
 	configsData := []configData{}
 
 	// --config-dump output must not contain any logs to be valid YAML
@@ -352,6 +390,9 @@ func (config *TGFConfig) setDefaultValues() {
 	if config.tgf.ConfigDump {
 		log.SetStdout(os.Stdout)
 	}
+
+	// First read local config files; this allows bootstrapping values earlier.
+	config.setConfigLocationFromLocalFiles()
 
 	// Fetch SSM configs
 	if config.awsConfigExist() {

--- a/config.go
+++ b/config.go
@@ -81,7 +81,7 @@ type TGFConfig struct {
 // TGFConfigBootstrap contains an entry specifying how to bootstrap the configuration
 type TGFConfigBootstrap struct {
 	ConfigLocation string `yaml:"config-location,omitempty" json:"config-location,omitempty" hcl:"config-location,omitempty"`
-	ConfigFiles    string `yaml:"config-files,omitempty" json:"config-files,omitempty" hcl:"config-files,omitempty"`
+	ConfigPaths    string `yaml:"config-paths,omitempty" json:"config-paths,omitempty" hcl:"config-paths,omitempty"`
 	SSMPath        string `yaml:"ssm-path,omitempty" json:"ssm-path,omitempty" hcl:"ssm-path,omitempty"`
 }
 
@@ -337,7 +337,7 @@ func (config *TGFConfig) InitAWS() error {
 	return nil
 }
 
-// Temporary structure to hold app.PsPath, app.ConfigLocation, app.ConfigFiles
+// Temporary structure to hold app.PsPath, app.ConfigLocation, app.ConfigPaths
 type configData struct {
 	Name   string
 	Raw    string
@@ -365,8 +365,8 @@ func (config *TGFConfig) setConfigLocationFromLocalFiles() {
 		if app.ConfigLocation == "" && localConfig.ConfigLocation != "" {
 			app.ConfigLocation = localConfig.ConfigLocation
 		}
-		if app.ConfigFiles == "" && localConfig.ConfigFiles != "" {
-			app.ConfigFiles = localConfig.ConfigFiles
+		if app.ConfigFiles == "" && localConfig.ConfigPaths != "" {
+			app.ConfigFiles = localConfig.ConfigPaths
 		}
 		if (app.PsPath == defaultSSMParameterFolder || app.PsPath == "") && localConfig.SSMPath != "" {
 			app.PsPath = localConfig.SSMPath

--- a/config_run_test.go
+++ b/config_run_test.go
@@ -16,16 +16,6 @@ import (
 )
 
 func setup(t *testing.T, testFunction func()) (string, string) {
-	// To ensure that the test is not altered by the environment
-	env := os.Environ()
-	os.Clearenv()
-	defer func() {
-		for i := range env {
-			values := strings.SplitN(env[i], "=", 2)
-			os.Setenv(values[0], values[1])
-		}
-	}()
-
 	// Create temp dir and config file
 	tempDir, _ := filepath.EvalSymlinks(must(os.MkdirTemp("", "TestGoMain")).(string))
 	testTgfUserConfigFile := fmt.Sprintf("%s/tgf.user.config", tempDir)
@@ -35,6 +25,16 @@ func setup(t *testing.T, testFunction func()) (string, string) {
 		docker-image-version: x
 	`).UnIndent().TrimSpace())
 	os.WriteFile(testTgfUserConfigFile, tgfConfig, 0644)
+
+	// To ensure that the test is not altered by the environment
+	env := os.Environ()
+	os.Clearenv()
+	defer func() {
+		for i := range env {
+			values := strings.SplitN(env[i], "=", 2)
+			os.Setenv(values[0], values[1])
+		}
+	}()
 
 	// Capture the outputs
 	var logBuffer bytes.Buffer

--- a/config_test.go
+++ b/config_test.go
@@ -534,27 +534,27 @@ func TestSetConfigLocationFromLocalFiles(t *testing.T) {
 		name                   string
 		configFiles            map[string]string // file name -> content.
 		expectedConfigLocation string
-		expectedConfigFiles    string
+		expectedConfigPaths    string
 		expectedSSMPath        string
 		disableUserConfig      bool
 	}{
 		{
 			name: "Basic config-location from .tgf.config",
 			configFiles: map[string]string{
-				".tgf.config": `config-location: coveo-bootstrap-us-east-1.s3.amazonaws.com/tgf-config`,
+				".tgf.config": `config-location: kovio-bootstrapz-us-east-1.s3.amazonaws.com/tgf-configz`,
 			},
-			expectedConfigLocation: "coveo-bootstrap-us-east-1.s3.amazonaws.com/tgf-config",
+			expectedConfigLocation: "kovio-bootstrapz-us-east-1.s3.amazonaws.com/tgf-configz",
 		},
 		{
 			name: "All bootstrap fields from .tgf.config",
 			configFiles: map[string]string{
 				".tgf.config": `
-config-location: coveo-bootstrap-us-east-1.s3.amazonaws.com/tgf-config
-config-files: TGFConfig:CustomConfig
+config-location: koveo-bootstrapz-us-east-1.s3.amazonaws.com/tgf-configz
+config-paths: TGFConfig:CustomConfig
 ssm-path: /custom/tgf`,
 			},
-			expectedConfigLocation: "coveo-bootstrap-us-east-1.s3.amazonaws.com/tgf-config",
-			expectedConfigFiles:    "TGFConfig:CustomConfig",
+			expectedConfigLocation: "koveo-bootstrapz-us-east-1.s3.amazonaws.com/tgf-configz",
+			expectedConfigPaths:    "TGFConfig:CustomConfig",
 			expectedSSMPath:        "/custom/tgf",
 		},
 		{
@@ -577,26 +577,26 @@ ssm-path: /custom/tgf`,
 		{
 			name: "JSON format configuration",
 			configFiles: map[string]string{
-				".tgf.config": `{"config-location": "json-location", "config-files": "JsonConfig"}`,
+				".tgf.config": `{"config-location": "json-location", "config-paths": "JsonConfig"}`,
 			},
 			expectedConfigLocation: "json-location",
-			expectedConfigFiles:    "JsonConfig",
+			expectedConfigPaths:    "JsonConfig",
 		},
 		{
 			name: "HCL format configuration",
 			configFiles: map[string]string{
 				".tgf.config": `config-location = "hcl-location"
-config-files = "HclConfig"`,
+config-paths = "HclConfig"`,
 			},
 			expectedConfigLocation: "hcl-location",
-			expectedConfigFiles:    "HclConfig",
+			expectedConfigPaths:    "HclConfig",
 		},
 		{
 			name: "Partial bootstrap config - only some fields",
 			configFiles: map[string]string{
-				".tgf.config": `config-files: OnlyFiles`,
+				".tgf.config": `config-paths: OnlyFiles`,
 			},
-			expectedConfigFiles: "OnlyFiles",
+			expectedConfigPaths: "OnlyFiles",
 		},
 		{
 			name: "Invalid config file - should be skipped",
@@ -645,7 +645,7 @@ config-files = "HclConfig"`,
 			cfg.setConfigLocationFromLocalFiles()
 
 			assert.Equal(t, tt.expectedConfigLocation, app.ConfigLocation, "ConfigLocation mismatch")
-			assert.Equal(t, tt.expectedConfigFiles, app.ConfigFiles, "ConfigPaths mismatch")
+			assert.Equal(t, tt.expectedConfigPaths, app.ConfigFiles, "ConfigPaths mismatch")
 
 			expectedPsPath := tt.expectedSSMPath
 			if expectedPsPath == "" {
@@ -672,7 +672,7 @@ func TestSetConfigLocationFromLocalFiles_PreexistingValues(t *testing.T) {
 
 	configContent := `
 config-location: new-location
-config-files: new-files
+config-paths: new-files
 ssm-path: /new/path`
 	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, ".tgf.config"), []byte(configContent), 0644))
 
@@ -756,7 +756,7 @@ func TestCLIParametersOverrideConfigFile(t *testing.T) {
 
 	configContent := `
 config-location: file-config-location
-config-files: file-config-files
+config-paths: file-config-paths
 ssm-path: /file/ssm/path`
 	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, ".tgf.config"), []byte(configContent), 0644))
 
@@ -771,21 +771,28 @@ ssm-path: /file/ssm/path`
 			name:                   "override config-location",
 			cliArgs:                []string{"--config-location", "cli-config-location"},
 			expectedConfigLocation: "cli-config-location",
-			expectedConfigFiles:    "file-config-files",
+			expectedConfigFiles:    "file-config-paths",
 			expectedSSMPath:        "/file/ssm/path",
 		},
 		{
 			name:                   "override config-files",
-			cliArgs:                []string{"--config-files", "cli-config-files"},
+			cliArgs:                []string{"--config-files", "cli-config-paths"},
 			expectedConfigLocation: "file-config-location",
-			expectedConfigFiles:    "cli-config-files",
+			expectedConfigFiles:    "cli-config-paths",
+			expectedSSMPath:        "/file/ssm/path",
+		},
+		{
+			name:                   "override config-paths", // tests the --config-paths alias
+			cliArgs:                []string{"--config-paths", "cli-config-paths"},
+			expectedConfigLocation: "file-config-location",
+			expectedConfigFiles:    "cli-config-paths",
 			expectedSSMPath:        "/file/ssm/path",
 		},
 		{
 			name:                   "override ssm-path",
 			cliArgs:                []string{"--ssm-path", "/cli/ssm/path"},
 			expectedConfigLocation: "file-config-location",
-			expectedConfigFiles:    "file-config-files",
+			expectedConfigFiles:    "file-config-paths",
 			expectedSSMPath:        "/cli/ssm/path",
 		},
 		{
@@ -806,7 +813,7 @@ ssm-path: /file/ssm/path`
 				"--ssm-path", "/cli/mixed/path",
 			},
 			expectedConfigLocation: "cli-mixed-location",
-			expectedConfigFiles:    "file-config-files",
+			expectedConfigFiles:    "file-config-paths",
 			expectedSSMPath:        "/cli/mixed/path",
 		},
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -528,3 +528,325 @@ func setupServer(t *testing.T) *httptest.Server {
 
 	return ts
 }
+
+func TestSetConfigLocationFromLocalFiles(t *testing.T) {
+	tests := []struct {
+		name                   string
+		configFiles            map[string]string // file name -> content.
+		expectedConfigLocation string
+		expectedConfigFiles    string
+		expectedSSMPath        string
+		disableUserConfig      bool
+	}{
+		{
+			name: "Basic config-location from .tgf.config",
+			configFiles: map[string]string{
+				".tgf.config": `config-location: coveo-bootstrap-us-east-1.s3.amazonaws.com/tgf-config`,
+			},
+			expectedConfigLocation: "coveo-bootstrap-us-east-1.s3.amazonaws.com/tgf-config",
+		},
+		{
+			name: "All bootstrap fields from .tgf.config",
+			configFiles: map[string]string{
+				".tgf.config": `
+config-location: coveo-bootstrap-us-east-1.s3.amazonaws.com/tgf-config
+config-files: TGFConfig:CustomConfig
+ssm-path: /custom/tgf`,
+			},
+			expectedConfigLocation: "coveo-bootstrap-us-east-1.s3.amazonaws.com/tgf-config",
+			expectedConfigFiles:    "TGFConfig:CustomConfig",
+			expectedSSMPath:        "/custom/tgf",
+		},
+		{
+			name: "User config overrides .tgf.config",
+			configFiles: map[string]string{
+				".tgf.config":     `config-location: old-location`,
+				"tgf.user.config": `config-location: new-location`,
+			},
+			expectedConfigLocation: "new-location",
+		},
+		{
+			name: "User config disabled - only .tgf.config used",
+			configFiles: map[string]string{
+				".tgf.config":     `config-location: main-location`,
+				"tgf.user.config": `config-location: user-location`,
+			},
+			disableUserConfig:      true,
+			expectedConfigLocation: "main-location",
+		},
+		{
+			name: "JSON format configuration",
+			configFiles: map[string]string{
+				".tgf.config": `{"config-location": "json-location", "config-files": "JsonConfig"}`,
+			},
+			expectedConfigLocation: "json-location",
+			expectedConfigFiles:    "JsonConfig",
+		},
+		{
+			name: "HCL format configuration",
+			configFiles: map[string]string{
+				".tgf.config": `config-location = "hcl-location"
+config-files = "HclConfig"`,
+			},
+			expectedConfigLocation: "hcl-location",
+			expectedConfigFiles:    "HclConfig",
+		},
+		{
+			name: "Partial bootstrap config - only some fields",
+			configFiles: map[string]string{
+				".tgf.config": `config-files: OnlyFiles`,
+			},
+			expectedConfigFiles: "OnlyFiles",
+		},
+		{
+			name: "Invalid config file - should be skipped",
+			configFiles: map[string]string{
+				".tgf.config": `invalid: yaml: content: [`,
+			},
+		},
+		{
+			name: "Empty config file",
+			configFiles: map[string]string{
+				".tgf.config": ``,
+			},
+		},
+		{
+			name: "No bootstrap fields in config",
+			configFiles: map[string]string{
+				".tgf.config": `docker-image: coveo/tgf`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir, err := os.MkdirTemp("", "TestSetConfigLocationFromLocalFiles")
+			assert.NoError(t, err)
+			tempDir, _ = filepath.EvalSymlinks(tempDir)
+
+			currentDir, _ := os.Getwd()
+			defer func() {
+				assert.NoError(t, os.Chdir(currentDir))
+				assert.NoError(t, os.RemoveAll(tempDir))
+			}()
+
+			testDir := tempDir
+			for fileName, content := range tt.configFiles {
+				fullPath := filepath.Join(tempDir, fileName)
+				assert.NoError(t, os.WriteFile(fullPath, []byte(content), 0644))
+			}
+
+			assert.NoError(t, os.Chdir(testDir))
+
+			app := NewTestApplication(nil, true)
+			app.DisableUserConfig = tt.disableUserConfig
+
+			cfg := &TGFConfig{tgf: app}
+			cfg.setConfigLocationFromLocalFiles()
+
+			assert.Equal(t, tt.expectedConfigLocation, app.ConfigLocation, "ConfigLocation mismatch")
+			assert.Equal(t, tt.expectedConfigFiles, app.ConfigFiles, "ConfigFiles mismatch")
+
+			expectedPsPath := tt.expectedSSMPath
+			if expectedPsPath == "" {
+				expectedPsPath = defaultSSMParameterFolder // Default should remain if not set
+			}
+			assert.Equal(t, expectedPsPath, app.PsPath, "PsPath mismatch")
+		})
+	}
+}
+
+func TestSetConfigLocationFromLocalFiles_PreexistingValues(t *testing.T) {
+	// This ultimately ensures that CLI parameters take priority
+	tempDir, err := os.MkdirTemp("", "TestPreexistingValues")
+	assert.NoError(t, err)
+	tempDir, _ = filepath.EvalSymlinks(tempDir)
+
+	currentDir, _ := os.Getwd()
+	defer func() {
+		assert.NoError(t, os.Chdir(currentDir))
+		assert.NoError(t, os.RemoveAll(tempDir))
+	}()
+
+	assert.NoError(t, os.Chdir(tempDir))
+
+	configContent := `
+config-location: new-location
+config-files: new-files
+ssm-path: /new/path`
+	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, ".tgf.config"), []byte(configContent), 0644))
+
+	app := NewTestApplication(nil, true)
+	app.ConfigLocation = "existing-location"
+	app.ConfigFiles = "existing-files"
+	app.PsPath = "/existing/path"
+
+	config := &TGFConfig{tgf: app}
+	config.setConfigLocationFromLocalFiles()
+
+	assert.Equal(t, "existing-location", app.ConfigLocation, "ConfigLocation should not be overwritten")
+	assert.Equal(t, "existing-files", app.ConfigFiles, "ConfigFiles should not be overwritten")
+	assert.Equal(t, "/existing/path", app.PsPath, "PsPath should not be overwritten")
+}
+
+func TestSetConfigLocationFromLocalFiles_SSMPathDefaultHandling(t *testing.T) {
+	// Test special handling of SSM path when it's the default value
+	tempDir, err := os.MkdirTemp("", "TestSSMPathDefault")
+	assert.NoError(t, err)
+	tempDir, _ = filepath.EvalSymlinks(tempDir)
+
+	currentDir, _ := os.Getwd()
+	defer func() {
+		assert.NoError(t, os.Chdir(currentDir))
+		assert.NoError(t, os.RemoveAll(tempDir))
+	}()
+
+	assert.NoError(t, os.Chdir(tempDir))
+
+	configContent := `ssm-path: /custom/ssm/path`
+	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, ".tgf.config"), []byte(configContent), 0644))
+
+	tests := []struct {
+		name           string
+		initialPsPath  string
+		expectedPsPath string
+	}{
+		{
+			name:           "Default SSM path should be overwritten",
+			initialPsPath:  defaultSSMParameterFolder,
+			expectedPsPath: "/custom/ssm/path",
+		},
+		{
+			name:           "Empty SSM path should be overwritten",
+			initialPsPath:  "",
+			expectedPsPath: "/custom/ssm/path",
+		},
+		{
+			name:           "Custom SSM path should not be overwritten",
+			initialPsPath:  "/my/custom/path",
+			expectedPsPath: "/my/custom/path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := NewTestApplication(nil, true)
+			app.PsPath = tt.initialPsPath
+
+			config := &TGFConfig{tgf: app}
+			config.setConfigLocationFromLocalFiles()
+
+			assert.Equal(t, tt.expectedPsPath, app.PsPath)
+		})
+	}
+}
+
+func TestCLIParametersOverrideConfigFile(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "TestCLIOverride")
+	assert.NoError(t, err)
+	tempDir, _ = filepath.EvalSymlinks(tempDir)
+
+	currentDir, _ := os.Getwd()
+	defer func() {
+		assert.NoError(t, os.Chdir(currentDir))
+		assert.NoError(t, os.RemoveAll(tempDir))
+	}()
+
+	assert.NoError(t, os.Chdir(tempDir))
+
+	configContent := `
+config-location: file-config-location
+config-files: file-config-files
+ssm-path: /file/ssm/path`
+	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, ".tgf.config"), []byte(configContent), 0644))
+
+	tests := []struct {
+		name                   string
+		cliArgs                []string
+		expectedConfigLocation string
+		expectedConfigFiles    string
+		expectedSSMPath        string
+	}{
+		{
+			name:                   "override config-location",
+			cliArgs:                []string{"--config-location", "cli-config-location"},
+			expectedConfigLocation: "cli-config-location",
+			expectedConfigFiles:    "file-config-files",
+			expectedSSMPath:        "/file/ssm/path",
+		},
+		{
+			name:                   "override config-files",
+			cliArgs:                []string{"--config-files", "cli-config-files"},
+			expectedConfigLocation: "file-config-location",
+			expectedConfigFiles:    "cli-config-files",
+			expectedSSMPath:        "/file/ssm/path",
+		},
+		{
+			name:                   "override ssm-path",
+			cliArgs:                []string{"--ssm-path", "/cli/ssm/path"},
+			expectedConfigLocation: "file-config-location",
+			expectedConfigFiles:    "file-config-files",
+			expectedSSMPath:        "/cli/ssm/path",
+		},
+		{
+			name: "All CLI parameters override file values",
+			cliArgs: []string{
+				"--config-location", "cli-location",
+				"--config-files", "cli-files",
+				"--ssm-path", "/cli/path",
+			},
+			expectedConfigLocation: "cli-location",
+			expectedConfigFiles:    "cli-files",
+			expectedSSMPath:        "/cli/path",
+		},
+		{
+			name: "Mixed CLI and file values",
+			cliArgs: []string{
+				"--config-location", "cli-mixed-location",
+				"--ssm-path", "/cli/mixed/path",
+			},
+			expectedConfigLocation: "cli-mixed-location",
+			expectedConfigFiles:    "file-config-files",
+			expectedSSMPath:        "/cli/mixed/path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := NewTestApplication(tt.cliArgs, true)
+			InitConfig(app)
+
+			assert.Equal(t, tt.expectedConfigLocation, app.ConfigLocation, "ConfigLocation mismatch")
+			assert.Equal(t, tt.expectedConfigFiles, app.ConfigFiles, "ConfigFiles mismatch")
+			assert.Equal(t, tt.expectedSSMPath, app.PsPath, "SSM Path mismatch")
+		})
+	}
+}
+
+func TestCLIParametersWithoutConfigFile(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "TestCLINoFile")
+	assert.NoError(t, err)
+	tempDir, _ = filepath.EvalSymlinks(tempDir)
+
+	currentDir, _ := os.Getwd()
+	defer func() {
+		assert.NoError(t, os.Chdir(currentDir))
+		assert.NoError(t, os.RemoveAll(tempDir))
+	}()
+
+	assert.NoError(t, os.Chdir(tempDir))
+
+	cliArgs := []string{
+		"--config-location", "cli-only-location",
+		"--config-files", "cli-only-files",
+		"--ssm-path", "/cli/only/path",
+	}
+
+	app := NewTestApplication(cliArgs, true)
+	config := InitConfig(app)
+
+	assert.Equal(t, "cli-only-location", app.ConfigLocation)
+	assert.Equal(t, "cli-only-files", app.ConfigFiles)
+	assert.Equal(t, "/cli/only/path", app.PsPath)
+	assert.NotNil(t, config)
+}

--- a/config_test.go
+++ b/config_test.go
@@ -645,7 +645,7 @@ config-files = "HclConfig"`,
 			cfg.setConfigLocationFromLocalFiles()
 
 			assert.Equal(t, tt.expectedConfigLocation, app.ConfigLocation, "ConfigLocation mismatch")
-			assert.Equal(t, tt.expectedConfigFiles, app.ConfigFiles, "ConfigFiles mismatch")
+			assert.Equal(t, tt.expectedConfigFiles, app.ConfigFiles, "ConfigPaths mismatch")
 
 			expectedPsPath := tt.expectedSSMPath
 			if expectedPsPath == "" {
@@ -685,7 +685,7 @@ ssm-path: /new/path`
 	config.setConfigLocationFromLocalFiles()
 
 	assert.Equal(t, "existing-location", app.ConfigLocation, "ConfigLocation should not be overwritten")
-	assert.Equal(t, "existing-files", app.ConfigFiles, "ConfigFiles should not be overwritten")
+	assert.Equal(t, "existing-files", app.ConfigFiles, "ConfigPaths should not be overwritten")
 	assert.Equal(t, "/existing/path", app.PsPath, "PsPath should not be overwritten")
 }
 
@@ -817,7 +817,7 @@ ssm-path: /file/ssm/path`
 			InitConfig(app)
 
 			assert.Equal(t, tt.expectedConfigLocation, app.ConfigLocation, "ConfigLocation mismatch")
-			assert.Equal(t, tt.expectedConfigFiles, app.ConfigFiles, "ConfigFiles mismatch")
+			assert.Equal(t, tt.expectedConfigFiles, app.ConfigFiles, "ConfigPaths mismatch")
 			assert.Equal(t, tt.expectedSSMPath, app.PsPath, "SSM Path mismatch")
 		})
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -642,7 +642,7 @@ config-paths = "HclConfig"`,
 			app.DisableUserConfig = tt.disableUserConfig
 
 			cfg := &TGFConfig{tgf: app}
-			cfg.setConfigLocationFromLocalFiles()
+			cfg.setBootstrapVariablesFromLocalFiles()
 
 			assert.Equal(t, tt.expectedConfigLocation, app.ConfigLocation, "ConfigLocation mismatch")
 			assert.Equal(t, tt.expectedConfigPaths, app.ConfigFiles, "ConfigPaths mismatch")
@@ -682,7 +682,7 @@ ssm-path: /new/path`
 	app.PsPath = "/existing/path"
 
 	config := &TGFConfig{tgf: app}
-	config.setConfigLocationFromLocalFiles()
+	config.setBootstrapVariablesFromLocalFiles()
 
 	assert.Equal(t, "existing-location", app.ConfigLocation, "ConfigLocation should not be overwritten")
 	assert.Equal(t, "existing-files", app.ConfigFiles, "ConfigPaths should not be overwritten")
@@ -717,11 +717,6 @@ func TestSetConfigLocationFromLocalFiles_SSMPathDefaultHandling(t *testing.T) {
 			expectedPsPath: "/custom/ssm/path",
 		},
 		{
-			name:           "Empty SSM path should be overwritten",
-			initialPsPath:  "",
-			expectedPsPath: "/custom/ssm/path",
-		},
-		{
 			name:           "Custom SSM path should not be overwritten",
 			initialPsPath:  "/my/custom/path",
 			expectedPsPath: "/my/custom/path",
@@ -734,7 +729,7 @@ func TestSetConfigLocationFromLocalFiles_SSMPathDefaultHandling(t *testing.T) {
 			app.PsPath = tt.initialPsPath
 
 			config := &TGFConfig{tgf: app}
-			config.setConfigLocationFromLocalFiles()
+			config.setBootstrapVariablesFromLocalFiles()
 
 			assert.Equal(t, tt.expectedPsPath, app.PsPath)
 		})

--- a/config_test.go
+++ b/config_test.go
@@ -852,3 +852,65 @@ func TestCLIParametersWithoutConfigFile(t *testing.T) {
 	assert.Equal(t, "/cli/only/path", app.PsPath)
 	assert.NotNil(t, config)
 }
+
+func TestConfigLocationOverrideSources(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "TestConfigLocationOverrideSources")
+	assert.NoError(t, err)
+	tempDir, _ = filepath.EvalSymlinks(tempDir)
+
+	currentDir, _ := os.Getwd()
+	defer func() {
+		assert.NoError(t, os.Chdir(currentDir))
+		assert.NoError(t, os.RemoveAll(tempDir))
+	}()
+
+	assert.NoError(t, os.Chdir(tempDir))
+
+	configContent := `config-location: file-location`
+	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, ".tgf.config"), []byte(configContent), 0644))
+
+	tests := []struct {
+		name                   string
+		cliArgs                []string
+		envVar                 string
+		expectedConfigLocation string
+	}{
+		{
+			name:                   "File only",
+			cliArgs:                nil,
+			envVar:                 "",
+			expectedConfigLocation: "file-location",
+		},
+		{
+			name:                   "ENV override",
+			cliArgs:                nil,
+			envVar:                 "env-location",
+			expectedConfigLocation: "env-location",
+		},
+		{
+			name:                   "CLI override",
+			cliArgs:                []string{"--config-location", "cli-location"},
+			envVar:                 "",
+			expectedConfigLocation: "cli-location",
+		},
+		{
+			name:                   "CLI overrides ENV and file",
+			cliArgs:                []string{"--config-location", "cli-location"},
+			envVar:                 "env-location",
+			expectedConfigLocation: "cli-location",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envVar != "" {
+				t.Setenv("TGF_CONFIG_LOCATION", tt.envVar)
+			}
+
+			app := NewTestApplication(tt.cliArgs, false)
+			InitConfig(app)
+
+			assert.Equal(t, tt.expectedConfigLocation, app.ConfigLocation, "ConfigLocation mismatch")
+		})
+	}
+}


### PR DESCRIPTION
With this, it is possible to skip the SSM check for the `config-location` by using the `.tgf.config` file.

I also added support for `ssm-path` and `config-paths` to reflect the matching CLI options.

I added a `--config-paths` CLI flag that is an alias to `--config-files`, for consistency.

Fixed goreleaser's schema being too old (DT-7761)