### PR TITLE
feat: migrate to RunsOn pool= format

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,8 +20,8 @@ jobs:
 
     runs-on:
       - runs-on=${{ github.run_id }}
-      - pool=${{ vars.RUNS_ON_ENV_DEV }}__${{ matrix.pool }}
-      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - pool=cip-dev-v3__${{ matrix.pool }}
+      - env=cip-dev-v3
       - region=us-east-1
     steps:
       - name: Harden Runner
@@ -50,8 +50,8 @@ jobs:
   goreleaser-check:
     runs-on:
       - runs-on=${{ github.run_id }}
-      - pool=${{ vars.RUNS_ON_ENV_DEV }}__small_ubuntu_24_arm64
-      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - pool=cip-dev-v3__small_ubuntu_24_arm64
+      - env=cip-dev-v3
       - region=us-east-1
     steps:
       - name: Harden Runner
@@ -76,8 +76,8 @@ jobs:
   goreleaser-test-release:
     runs-on:
       - runs-on=${{ github.run_id }}
-      - pool=${{ vars.RUNS_ON_ENV_DEV }}__default_ubuntu_24_arm64
-      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - pool=cip-dev-v3__default_ubuntu_24_arm64
+      - env=cip-dev-v3
       - region=us-east-1
     steps:
       - name: Harden Runner

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,16 +14,25 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        include:
+          - pool: default_ubuntu_24_arm64
+          - pool: default_windows_2025_x64
 
-    runs-on: ${{ matrix.os }}
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - pool=${{ vars.RUNS_ON_ENV_DEV }}__${{ matrix.pool }}
+      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - region=us-east-1
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
         with:
           egress-policy: audit
 
+      - uses: coveo-platform/setup-runner@v1.1.1
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.25.9
@@ -39,14 +48,21 @@ jobs:
         run: go test -v ./...
 
   goreleaser-check:
-    runs-on: ubuntu-latest
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - pool=${{ vars.RUNS_ON_ENV_DEV }}__small_ubuntu_24_arm64
+      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - region=us-east-1
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
         with:
           egress-policy: audit
 
+      - uses: coveo-platform/setup-runner@v1.1.1
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.25.9
@@ -58,16 +74,23 @@ jobs:
           args: check
 
   goreleaser-test-release:
-    runs-on: ubuntu-latest
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - pool=${{ vars.RUNS_ON_ENV_DEV }}__default_ubuntu_24_arm64
+      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - region=us-east-1
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
         with:
           egress-policy: audit
 
+      - uses: coveo-platform/setup-runner@v1.1.1
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # goreleaser needs the whole history to build the release notes
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.25.9

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -9,18 +9,25 @@ permissions:
 jobs:
   release:
     permissions:
-      contents: write  # for goreleaser/goreleaser-action to create a GitHub release
+      contents: write # for goreleaser/goreleaser-action to create a GitHub release
     name: Tag
-    runs-on: ubuntu-latest
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - pool=${{ vars.RUNS_ON_ENV_DEV }}__default_ubuntu_24_arm64
+      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - region=us-east-1
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
         with:
           egress-policy: audit
 
+      - uses: coveo-platform/setup-runner@v1.1.1
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.25.9
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # goreleaser needs the whole history to build the release notes

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -13,8 +13,8 @@ jobs:
     name: Tag
     runs-on:
       - runs-on=${{ github.run_id }}
-      - pool=${{ vars.RUNS_ON_ENV_DEV }}__default_ubuntu_24_arm64
-      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - pool=cip-dev-v3__default_ubuntu_24_arm64
+      - env=cip-dev-v3
       - region=us-east-1
     steps:
       - name: Harden Runner

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -27,8 +27,8 @@ jobs:
   windows:
     runs-on:
       - runs-on=${{ github.run_id }}
-      - pool=${{ vars.RUNS_ON_ENV_DEV }}__default_windows_2025_x64
-      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - pool=cip-dev-v3__default_windows_2025_x64
+      - env=cip-dev-v3
       - region=us-east-1
     steps:
       - name: Harden Runner

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, ubuntu-latest ]
+        os: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -20,18 +20,22 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - run: ./get-latest-tgf.sh
 
 
   windows:
-    runs-on: windows-latest
-
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - pool=${{ vars.RUNS_ON_ENV_DEV }}__default_windows_2025_x64
+      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - region=us-east-1
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
         with:
           egress-policy: audit
-
+      - uses: coveo-platform/setup-runner@v1.1.1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: ./get-latest-tgf.ps1
 
@@ -50,6 +54,7 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - uses: ./
         with:
           ref: ${{ github.head_ref }}


### PR DESCRIPTION
Migrates runs-on labels to the standard `pool=` format.

## Changes

### `pr.yml`

- **test**: `${{ matrix.os }}` → `pool=${{ matrix.pool }}`
  - _arch: x64 → arm64 (ubuntu), x64 (windows)_
  - _rationale: Matrix restructured to include pool labels. arm64 for ubuntu (Go, no x64 constraints), x64 for windows_
- **goreleaser-check**: `ubuntu-latest` → `pool=small_ubuntu_24_arm64`
  - _arch: x64 → arm64_
  - _size: GitHub-hosted → small_
  - _rationale: Lightweight goreleaser check with no x64 constraints; small runner sufficient_
- **goreleaser-test-release**: `ubuntu-latest` → `pool=default_ubuntu_24_arm64`
  - _arch: x64 → arm64_
  - _rationale: goreleaser snapshot release with CGO_ENABLED=0; no x64 dependencies_

### `tag.yml`

- **release**: `ubuntu-latest` → `pool=default_ubuntu_24_arm64`
  - _arch: x64 → arm64_
  - _rationale: Push-triggered goreleaser release with CGO_ENABLED=0; arm64 safe_

### `test-install.yml`

- **windows**: `windows-latest` → `pool=default_windows_2025_x64`

## Skipped

- `test-install.yml/posix` — Matrix includes macos-latest which RunsOn does not support
- `test-install.yml/action` — Matrix includes macos-latest which RunsOn does not support

## Notes

- setup-runner upgraded to v1.1.1
- Formatted with yamlfmt
- Expression pools (`${{ matrix.pool }}`) used for matrix-driven runner selection
- [Migration guide](https://devportal.dep.cloud.coveo.com/docs/default/component/runs-on/migration/)