### PR TITLE
fix: Do not inject XDG_DATA_DIRS when running docker

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,6 +24,7 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.25.9
@@ -47,6 +48,7 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.25.9
@@ -68,6 +70,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # goreleaser needs the whole history to build the release notes
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.25.9

--- a/config.go
+++ b/config.go
@@ -72,7 +72,7 @@ type TGFConfig struct {
 	AutoUpdate              bool              `yaml:"auto-update,omitempty" json:"auto-update,omitempty" hcl:"auto-update,omitempty"`
 
 	imageBuildConfigs []TGFConfigBuild // List of config built from previous build configs
-	tgf                                 *TGFApplication
+	tgf               *TGFApplication
 }
 
 // TGFConfigBootstrap contains an entry specifying how to bootstrap the configuration

--- a/docker.go
+++ b/docker.go
@@ -582,7 +582,7 @@ func getEnviron(noHome bool) (result []string) {
 		case
 			"_", "PWD", "PS1", "OLDPWD", "TMPDIR",
 			"PROMPT", "SHELL", "SH", "ZSH", "HOME",
-			"LANG", "LC_CTYPE", "DISPLAY", "TERM":
+			"LANG", "LC_CTYPE", "DISPLAY", "TERM", "XDG_DATA_DIRS":
 		default:
 			result = append(result, "-e")
 			result = append(result, split[0])


### PR DESCRIPTION
Do not inject `XDG_DATA_DIRS` because it can have side effects.